### PR TITLE
logger interface and options

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lovoo/goka/codec"
 	"github.com/lovoo/goka/kafka"
+	"github.com/lovoo/goka/logger"
 	"github.com/lovoo/goka/mock"
 
 	"github.com/facebookgo/ensure"
@@ -355,6 +356,7 @@ func TestContext_Join(t *testing.T) {
 		msg:   &message{Key: key},
 		pviews: map[string]*partition{
 			string(table): &partition{
+				log: logger.Default(),
 				st: &storageProxy{
 					Storage: st,
 				},

--- a/errors_test.go
+++ b/errors_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
-
 	"github.com/lovoo/goka/codec"
 )
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,34 @@
+package logger
+
+import "log"
+
+var (
+	defaultLogger = &std{}
+)
+
+// Logger is the interface Goka and its subpackages use for logging.
+type Logger interface {
+	// Printf will be used for informational messages. These can be thought of
+	// having an 'Info'-level in a structured logger.
+	Printf(string, ...interface{})
+	// Panicf will be only called an unexpected programming error such as a type
+	// assertion which should never fail. Regular errors will be returned out
+	// from the library.
+	Panicf(string, ...interface{})
+}
+
+// std bridges the logger calls to the standard library log.
+type std struct{}
+
+func (s *std) Printf(msg string, args ...interface{}) {
+	log.Printf(msg, args...)
+}
+
+func (s *std) Panicf(msg string, args ...interface{}) {
+	log.Panicf(msg, args...)
+}
+
+// Default returns the standard library logger
+func Default() Logger {
+	return defaultLogger
+}

--- a/mocks.go
+++ b/mocks.go
@@ -67,7 +67,7 @@ func (cm *clientMock) GetOffset(topic string, partitionID int32, time int64) (in
 	case sarama.OffsetOldest:
 		offset, hasOffset = cm.oldestOffsets[fmt.Sprintf("%s/%d", topic, partitionID)]
 	default:
-		log.Fatalln("we don't mock this case")
+		log.Panic("we don't mock this case")
 	}
 
 	if hasOffset {

--- a/monitor/monitoring.go
+++ b/monitor/monitoring.go
@@ -3,10 +3,10 @@ package monitor
 import (
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"sync"
 
+	"github.com/lovoo/goka/logger"
 	"github.com/lovoo/goka/templates"
 
 	"net/http"
@@ -20,16 +20,22 @@ var baseTemplates = append(templates.BaseTemplates, "templates/monitor/menu.go.h
 // Server is the main type used by client sot interact with the monitoring
 // functionality of goka.
 type Server struct {
-	m sync.RWMutex
+	log logger.Logger
+	m   sync.RWMutex
 
 	basePath string
 	procs    []*processorStats
 }
 
 // NewServer creates a new Server
-func NewServer(basePath string, router *mux.Router) *Server {
+func NewServer(basePath string, router *mux.Router, opts ...Option) *Server {
 	srv := &Server{
+		log:      logger.Default(),
 		basePath: basePath,
+	}
+
+	for _, opt := range opts {
+		opt(srv)
 	}
 
 	sub := router.PathPrefix(basePath).Subrouter()
@@ -83,7 +89,7 @@ func (s *Server) index(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := tmpl.Execute(w, params); err != nil {
-		log.Printf("error rendering index template: %v", err)
+		s.log.Printf("error rendering index template: %v", err)
 	}
 }
 
@@ -122,7 +128,7 @@ func (s *Server) renderProcessor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err = tmpl.Execute(w, params); err != nil {
-		log.Printf("error rendering processor view: %v", err)
+		s.log.Printf("error rendering processor view: %v", err)
 	}
 }
 

--- a/monitor/option.go
+++ b/monitor/option.go
@@ -1,0 +1,13 @@
+package monitor
+
+import "github.com/lovoo/goka/logger"
+
+// Option is a function that applies a configuration to the server.
+type Option func(s *Server)
+
+// WithLogger sets the logger to use. By default, it logs to standard out.
+func WithLogger(l logger.Logger) Option {
+	return func(s *Server) {
+		s.log = l
+	}
+}

--- a/processor_test.go
+++ b/processor_test.go
@@ -12,12 +12,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/facebookgo/ensure"
-	"github.com/golang/mock/gomock"
 	"github.com/lovoo/goka/codec"
 	"github.com/lovoo/goka/kafka"
+	"github.com/lovoo/goka/logger"
 	"github.com/lovoo/goka/mock"
 	"github.com/lovoo/goka/storage"
+
+	"github.com/facebookgo/ensure"
+	"github.com/golang/mock/gomock"
 	metrics "github.com/rcrowley/go-metrics"
 )
 
@@ -892,7 +894,7 @@ func TestProcessor_HasGetStateless(t *testing.T) {
 	st := mock.NewMockStorage(ctrl)
 	p = &Processor{graph: DefineGroup(group, Persist(c))}
 	p.partitions = map[int32]*partition{
-		0: &partition{st: &storageProxy{Storage: st, partition: 0}},
+		0: &partition{log: logger.Default(), st: &storageProxy{Storage: st, partition: 0}},
 	}
 	p.partitionCount = 1
 

--- a/query/option.go
+++ b/query/option.go
@@ -1,5 +1,7 @@
 package query
 
+import "github.com/lovoo/goka/logger"
+
 // Option is a function that applies a configuration to the server.
 type Option func(s *Server)
 
@@ -8,5 +10,13 @@ type Option func(s *Server)
 func WithHumanizer(h Humanizer) Option {
 	return func(s *Server) {
 		s.humanizer = h
+	}
+}
+
+// WithLogger sets the logger to use. By default, it logs to the standard
+// library logger.
+func WithLogger(l logger.Logger) Option {
+	return func(s *Server) {
+		s.log = l
 	}
 }

--- a/query/option.go
+++ b/query/option.go
@@ -1,0 +1,12 @@
+package query
+
+// Option is a function that applies a configuration to the server.
+type Option func(s *Server)
+
+// WithHumanizer sets the humanizer to use for the queried values. By default,
+// the value will be printed out as JSON.
+func WithHumanizer(h Humanizer) Option {
+	return func(s *Server) {
+		s.humanizer = h
+	}
+}

--- a/query/query.go
+++ b/query/query.go
@@ -3,13 +3,13 @@ package query
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"sort"
 	"strings"
 	"sync"
 
 	"github.com/lovoo/goka"
+	"github.com/lovoo/goka/logger"
 	"github.com/lovoo/goka/templates"
 
 	"github.com/gorilla/mux"
@@ -44,7 +44,8 @@ func DefaultHumanizer() Humanizer {
 
 // Server is a provides HTTP routes for querying the group table.
 type Server struct {
-	m sync.RWMutex
+	log logger.Logger
+	m   sync.RWMutex
 
 	basePath  string
 	loader    templates.Loader
@@ -55,6 +56,7 @@ type Server struct {
 // NewServer creates a server with the given options.
 func NewServer(basePath string, router *mux.Router, opts ...Option) *Server {
 	srv := &Server{
+		log:       logger.Default(),
 		basePath:  basePath,
 		loader:    &templates.BinLoader{},
 		sources:   make(map[string]goka.Getter),
@@ -116,7 +118,7 @@ func (s *Server) executeQueryTemplate(w http.ResponseWriter, params map[string]i
 	params["base_path"] = s.basePath
 
 	if err := tmpl.Execute(w, params); err != nil {
-		log.Printf("error executing query template: %v", err)
+		s.log.Printf("error executing query template: %v", err)
 	}
 }
 

--- a/storage/leveldb_test.go
+++ b/storage/leveldb_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
+	"github.com/lovoo/goka/logger"
 )
 
 var keys []string
@@ -21,7 +22,7 @@ func init() {
 func BenchmarkStateStorage_unbatched(b *testing.B) {
 	tmpdir, err := ioutil.TempDir("", "benchmark_statestorage_unbatched")
 	ensure.Nil(b, err)
-	storage, err := newLeveldbStorage(tmpdir, false)
+	storage, err := newLeveldbStorage(logger.Default(), tmpdir, false)
 	ensure.Nil(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N*numWrites; i++ {
@@ -33,7 +34,7 @@ func BenchmarkStateStorage_unbatched(b *testing.B) {
 func BenchmarkStateStorage_batched(b *testing.B) {
 	tmpdir, err := ioutil.TempDir("", "benchmark_statestorage_batched")
 	ensure.Nil(b, err)
-	storage, err := newLeveldbStorage(tmpdir, true)
+	storage, err := newLeveldbStorage(logger.Default(), tmpdir, true)
 	ensure.Nil(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N*numWrites; i++ {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/lovoo/goka/codec"
+	"github.com/lovoo/goka/logger"
 
 	"github.com/facebookgo/ensure"
 	"github.com/rcrowley/go-metrics"
@@ -140,7 +141,7 @@ func TestSetGet_json(t *testing.T) {
 	)
 	testDbPath := "/tmp/statemanagertest.go"
 	os.RemoveAll(testDbPath)
-	storage, err := New(testDbPath, &codec.String{}, metrics.NewRegistry(), DefaultStorageSnapshotInterval)
+	storage, err := New(logger.Default(), testDbPath, &codec.String{}, metrics.NewRegistry(), DefaultStorageSnapshotInterval)
 	ensure.Nil(t, err)
 
 	hasKey, err = storage.Has("example1")

--- a/view_test.go
+++ b/view_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lovoo/goka/codec"
 	"github.com/lovoo/goka/kafka"
+	"github.com/lovoo/goka/logger"
 	"github.com/lovoo/goka/mock"
 	"github.com/lovoo/goka/storage"
 
@@ -22,6 +23,7 @@ var (
 func createTestView(t *testing.T, consumer kafka.Consumer, sb StorageBuilder, tm kafka.TopicManager) *View {
 	recoveredMessages = 0
 	opts := &voptions{
+		log:        logger.Default(),
 		tableCodec: new(codec.String),
 		updateCallback: func(s storage.Storage, partition int32, key string, value []byte) error {
 			if err := DefaultUpdate(s, partition, key, value); err != nil {


### PR DESCRIPTION
* Adds options for supplying the logger as an option to processors,
  views, emitters, monitor and query. This makes custom logging possible.

* Adds a default JSON marshaler for querying and changes the
  marshaler from a required parameter to an optional one.