### PR TITLE
iterator offset key skipping

### DIFF
--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -28,6 +28,9 @@ func (i *memiter) exhausted() bool {
 
 func (i *memiter) Next() bool {
 	i.current++
+	if string(i.Key()) == offsetKey {
+		i.current++
+	}
 	return !i.exhausted()
 }
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -46,11 +46,12 @@ func TestMemIter(t *testing.T) {
 
 	found := map[string]string{}
 
+	storage.Set(offsetKey, "not-returned")
 	for k, v := range kv {
 		storage.Set(k, v)
 	}
 
-	// released iterator should be immidiately exhausted
+	// released iterator should be immediately exhausted
 	iter := storage.Iterator()
 	iter.Release()
 	ensure.False(t, iter.Next(), "released iterator had a next")


### PR DESCRIPTION
* Skips the offset key while iterating over the storage. Returning
  the offset produces errors as users only expect to receive
  objects they've stored in the storage themselves and the stored
  offset can be considered an implementation detail.