### PR TITLE
deletion semantics

### DIFF
--- a/examples/testing/context_mock.go
+++ b/examples/testing/context_mock.go
@@ -4,9 +4,10 @@
 package main
 
 import (
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	goka "github.com/lovoo/goka"
-	time "time"
 )
 
 // Mock of Context interface
@@ -28,6 +29,14 @@ func NewMockContext(ctrl *gomock.Controller) *MockContext {
 
 func (_m *MockContext) EXPECT() *_MockContextRecorder {
 	return _m.recorder
+}
+
+func (_m *MockContext) Delete() {
+	_m.ctrl.Call(_m, "Delete")
+}
+
+func (_mr *_MockContextRecorder) Delete() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete")
 }
 
 func (_m *MockContext) Emit(_param0 goka.Stream, _param1 string, _param2 interface{}) {

--- a/options.go
+++ b/options.go
@@ -50,6 +50,10 @@ func DefaultViewStoragePath() string {
 // DefaultUpdate can be used in the function passed to WithUpdateCallback and
 // WithViewCallback.
 func DefaultUpdate(s storage.Storage, partition int32, key string, value []byte) error {
+	if value == nil {
+		s.Delete(key)
+	}
+
 	return s.SetEncoded(key, value)
 }
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -570,6 +570,7 @@ func TestProcessor_StartWithErrorAfterRebalance(t *testing.T) {
 		final = make(chan bool)
 		ch    = make(chan kafka.Event)
 		p     = createProcessor(t, ctrl, consumer, 3, sb)
+		value = []byte("value")
 	)
 
 	// -- expectations --
@@ -586,7 +587,7 @@ func TestProcessor_StartWithErrorAfterRebalance(t *testing.T) {
 	consumer.EXPECT().AddPartition(tableName(group), int32(2), int64(123))
 	// 3. message
 	gomock.InOrder(
-		st.EXPECT().SetEncoded("key", nil).Return(nil),
+		st.EXPECT().SetEncoded("key", value).Return(nil),
 		st.EXPECT().SetOffset(int64(1)),
 		st.EXPECT().MarkRecovered(),
 		st.EXPECT().Sync(),
@@ -621,6 +622,7 @@ func TestProcessor_StartWithErrorAfterRebalance(t *testing.T) {
 		Partition: 1,
 		Offset:    1,
 		Key:       "key",
+		Value:     value,
 	}
 	err = syncWith(t, ch, 1) // with partition
 	ensure.Nil(t, err)
@@ -650,6 +652,7 @@ func TestProcessor_Start(t *testing.T) {
 		final = make(chan bool)
 		ch    = make(chan kafka.Event)
 		p     = createProcessor(t, ctrl, consumer, 3, sb)
+		value = []byte("value")
 	)
 
 	// -- expectations --
@@ -663,7 +666,7 @@ func TestProcessor_Start(t *testing.T) {
 	consumer.EXPECT().AddPartition(tableName(group), int32(1), int64(123))
 	consumer.EXPECT().AddPartition(tableName(group), int32(2), int64(123))
 	// 3. load message partition 1
-	st.EXPECT().SetEncoded("key", nil).Return(nil)
+	st.EXPECT().SetEncoded("key", value).Return(nil)
 	st.EXPECT().SetOffset(int64(1))
 	st.EXPECT().Sync()
 	st.EXPECT().MarkRecovered()
@@ -708,6 +711,7 @@ func TestProcessor_Start(t *testing.T) {
 		Partition: 1,
 		Offset:    1,
 		Key:       "key",
+		Value:     value,
 	}
 	err = syncWith(t, ch, 1) // with partition 1
 	ensure.Nil(t, err)
@@ -802,6 +806,7 @@ func TestProcessor_StartWithTable(t *testing.T) {
 		ch       = make(chan kafka.Event)
 		p        = createProcessorWithTable(ctrl, consumer, 3, sb)
 		producer = p.producer.(*mock.MockProducer)
+		value    = []byte("value")
 	)
 
 	// -- expectations --
@@ -818,7 +823,7 @@ func TestProcessor_StartWithTable(t *testing.T) {
 	consumer.EXPECT().AddPartition(table, int32(1), int64(123))
 	consumer.EXPECT().AddPartition(table, int32(2), int64(123))
 	// 3. message to group table
-	st.EXPECT().SetEncoded("key", nil).Return(nil)
+	st.EXPECT().SetEncoded("key", value).Return(nil)
 	st.EXPECT().SetOffset(int64(1))
 	st.EXPECT().MarkRecovered()
 	st.EXPECT().Sync()
@@ -867,6 +872,7 @@ func TestProcessor_StartWithTable(t *testing.T) {
 		Partition: 1,
 		Offset:    1,
 		Key:       "key",
+		Value:     value,
 	}
 	err = syncWith(t, ch, 1)
 	ensure.Nil(t, err)

--- a/storage/append.go
+++ b/storage/append.go
@@ -1,0 +1,96 @@
+package storage
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type file struct {
+	file      io.WriteCloser
+	codec     Codec
+	recovered bool
+
+	bytesWritten int64
+}
+
+func NewFile(path string, part int32, codec Codec) (Storage, error) {
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("error creating storage directory: %v", err)
+	}
+
+	f, err := os.OpenFile(filepath.Join(path, fmt.Sprintf("part-%d", part)), os.O_CREATE|os.O_RDWR|os.O_APPEND, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+
+	return &file{file: f}, nil
+}
+
+func (f *file) Recovered() bool {
+	return f.recovered
+}
+
+func (f *file) MarkRecovered() error {
+	f.recovered = true
+	return nil
+}
+
+func (f *file) Has(key string) (bool, error) {
+	return false, nil
+}
+
+func (f *file) Get(key string) (interface{}, error) {
+	return nil, nil
+}
+
+func (f *file) Set(key string, val interface{}) error {
+	data, err := f.codec.Encode(val)
+	if err != nil {
+		return err
+	}
+
+	return f.SetEncoded(key, data)
+}
+
+func (f *file) SetEncoded(key string, val []byte) error {
+	num, err := f.file.Write(val)
+	if err != nil {
+		return err
+	}
+
+	f.bytesWritten += int64(num)
+
+	if _, err := f.file.Write([]byte("\n")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *file) Delete(string) error {
+	return nil
+}
+
+func (f *file) GetOffset(def int64) (int64, error) {
+	return def, nil
+}
+
+func (f *file) SetOffset(val int64) error {
+	return nil
+}
+
+func (f *file) Iterator() (Iterator, error) {
+	return new(NullIter), nil
+}
+
+func (f *file) Open() error {
+	return nil
+}
+
+func (f *file) Close() error {
+	return f.file.Close()
+}
+
+func (f *file) Sync() {}


### PR DESCRIPTION
* Adds nil support for Kafka's nil message semantics. Receiving a nil
  message in a View will now remove the associated key from the local
  cache.

* Adds Delete() method on Context. Calling delete will evict the key
  from the local cache and send a nil message to the group table in
  Kafka under the associated key.