### PR TITLE
Evict method for Views

### DIFF
--- a/mocks.go
+++ b/mocks.go
@@ -2,10 +2,42 @@ package goka
 
 import (
 	"fmt"
+	"hash"
 	"log"
 
 	"github.com/Shopify/sarama"
 )
+
+// constHasher implements a hasher that will always return the specified
+// partition. Doesn't properly implement the Hash32 interface, use only in
+// tests.
+type constHasher struct {
+	partition uint32
+}
+
+func (ch *constHasher) Sum(b []byte) []byte {
+	return nil
+}
+
+func (ch *constHasher) Sum32() uint32 {
+	return ch.partition
+}
+
+func (ch *constHasher) BlockSize() int {
+	return 0
+}
+
+func (ch *constHasher) Reset() {}
+
+func (ch *constHasher) Size() int { return 4 }
+
+func (ch *constHasher) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func NewConstHasher(part uint32) hash.Hash32 {
+	return &constHasher{partition: part}
+}
 
 type clientMock struct {
 	topics        []string

--- a/view.go
+++ b/view.go
@@ -265,6 +265,17 @@ func (v *View) Iterator() (storage.Iterator, error) {
 	return storage.NewMultiIterator(iters), nil
 }
 
+// Evict removes the given key only from the local cache. In order to delete a
+// key from Kafka and other Views, context.Delete should be used on a Processor.
+func (v *View) Evict(key string) error {
+	s, err := v.find(key)
+	if err != nil {
+		return err
+	}
+
+	return s.Delete(key)
+}
+
 func (v *View) run() {
 	defer close(v.done)
 	v.opts.log.Printf("View: started")


### PR DESCRIPTION
* Adds an Evict method for Views. Evict clears the key from the
  local cache.