### PR TITLE
timestamp passing in simple consumer

### DIFF
--- a/kafka/simple_consumer.go
+++ b/kafka/simple_consumer.go
@@ -133,6 +133,7 @@ func (c *simpleConsumer) run(pc sarama.PartitionConsumer, topic string, partitio
 			Offset:    m.Offset,
 			Key:       string(m.Key),
 			Value:     m.Value,
+			Timestamp: m.Timestamp,
 		}:
 		case <-c.dying:
 			return


### PR DESCRIPTION
* Passes the timestamp forward in simple consumer. Fixes an issue
  where views constantly get zero times.