### PR TITLE
Expose new methods in context to set and get custom key

### DIFF
--- a/context.go
+++ b/context.go
@@ -25,8 +25,14 @@ type Context interface {
 	// Value returns the value of the key in the group table.
 	Value() interface{}
 
+	// ValueForKey returns the value of the key provided in the group table.
+	ValueForKey(key string) interface{}
+
 	// SetValue updates the value of the key in the group table.
 	SetValue(value interface{})
+
+	// SetValueForKey updates the value of the key provided in the group table.
+	SetValueForKey(key string, value interface{})
 
 	// Delete deletes a value from the group table. IMPORTANT: this deletes the
 	// value associated with the key from both the local cache and the persisted
@@ -148,9 +154,25 @@ func (ctx *context) Value() interface{} {
 	return val
 }
 
+// ValueForKey returns the value of the key provided in the group table.
+func (ctx *context) ValueForKey(key string) interface{} {
+	val, err := ctx.valueForKey(string(key))
+	if err != nil {
+		ctx.Fail(err)
+	}
+	return val
+}
+
 // SetValue updates the value of the key in the group table.
 func (ctx *context) SetValue(value interface{}) {
 	if err := ctx.setValueForKey(string(ctx.msg.Key), value); err != nil {
+		ctx.Fail(err)
+	}
+}
+
+// SetValueForKey updates the value of the key provided in the group table.
+func (ctx *context) SetValueForKey(key string, value interface{}) {
+	if err := ctx.setValueForKey(key, value); err != nil {
 		ctx.Fail(err)
 	}
 }

--- a/examples/testing/context_mock.go
+++ b/examples/testing/context_mock.go
@@ -101,6 +101,14 @@ func (_mr *_MockContextRecorder) SetValue(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetValue", arg0)
 }
 
+func (_m *MockContext) SetValueForKey(_param0 string, _param1 interface{}) {
+	_m.ctrl.Call(_m, "SetValueForKey", _param0, _param1)
+}
+
+func (_mr *_MockContextRecorder) SetValueForKey(arg0 string, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetValueForKey", arg0, arg1)
+}
+
 func (_m *MockContext) Timestamp() time.Time {
 	ret := _m.ctrl.Call(_m, "Timestamp")
 	ret0, _ := ret[0].(time.Time)
@@ -129,4 +137,14 @@ func (_m *MockContext) Value() interface{} {
 
 func (_mr *_MockContextRecorder) Value() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Value")
+}
+
+func (_m *MockContext) ValueForKey(_param0 string) interface{} {
+	ret := _m.ctrl.Call(_m, "ValueForKey", _param0)
+	ret0, _ := ret[0].(interface{})
+	return ret0
+}
+
+func (_mr *_MockContextRecorder) ValueForKey(_param0 string) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ValueForKey", _param0)
 }


### PR DESCRIPTION
Hi,
Sometimes, messages we receive don't have any key.
And sometimes we listen to multiple topics with different rules for the message keys.

It would be great to be able to store value in the context via a custom key.