### PR TITLE
nil pointer panic when closing producer 

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -43,9 +43,8 @@ func NewProducer(brokers []string, config *sarama.Config, registry metrics.Regis
 
 func (p *producer) Close() error {
 	close(p.stop)
-	err := p.producer.Close()
 	<-p.done
-	return err
+	return p.producer.Close()
 }
 
 func (p *producer) Emit(topic string, key string, value []byte) *Promise {


### PR DESCRIPTION
This PR fixes #49. The issue is that we were closing the stop channel and the underlying producer at the same time. Since the select in `run()` is non-deterministic and the channels of the producer (errors and successes) may return nil if they are closed, sometimes the goroutine was getting a `nil` value back and trying to derefence the Metadata pointer.

We now first close the stop channel, that will force the goroutine in `run()` to exit. Afterwards, we close the underlying producer.