### PR TITLE
deletes partition consumer from map even on errors

### DIFF
--- a/kafka/simple_consumer.go
+++ b/kafka/simple_consumer.go
@@ -179,11 +179,11 @@ func (c *simpleConsumer) RemovePartition(topic string, partition int32) error {
 	if !has {
 		return fmt.Errorf("%s/%d was not added", topic, partition)
 	}
+	defer delete(c.partitions, tp) // remove tp from map even in case of errors
 	err := pc.Close()
 	if err != nil {
 		return fmt.Errorf("error closing consumer for %s/%d: %v", topic, partition, err)
 	}
-	delete(c.partitions, tp)
 	return nil
 }
 

--- a/processor.go
+++ b/processor.go
@@ -348,7 +348,7 @@ func (g *Processor) run() {
 		case *kafka.Assignment:
 			err := g.rebalance(*ev)
 			if err != nil {
-				g.fail(err)
+				g.fail(fmt.Errorf("error on rebalance: %v", err))
 				return
 			}
 
@@ -398,6 +398,7 @@ func (g *Processor) run() {
 		case *kafka.Error:
 			g.fail(ev.Err)
 			return
+
 		default:
 			g.fail(fmt.Errorf("processor: cannot handle %T = %v", ev, ev))
 			return


### PR DESCRIPTION
If a partition consumer is removed and returns an error on `Close()`, it is not removed from the map of partition consumers (inside `kafka/simple_consumer.go`). When stopping the processor later on, that partition consumer will be closed again, causing a `close of closed channel` panic.

This PR removes the partition consumer from the map even if it returns an error on close.