### PR TITLE
use default channel size from sarama in kafka package

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -12,7 +12,6 @@ func CreateDefaultSaramaConfig(clientID string, partitioner sarama.PartitionerCo
 
 	config.Version = sarama.V0_10_1_0
 	config.ClientID = clientID
-	config.ChannelBufferSize = defaultChannelBufferSize
 
 	// consumer configuration
 	config.Consumer.Return.Errors = true

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// size of sarama buffer for consumer and producer
-	defaultChannelBufferSize = 10
+	defaultChannelBufferSize = 256
 
 	// time sarama-cluster assumes the processing of an event may take
 	defaultMaxProcessingTime = 1 * time.Second
@@ -52,7 +52,11 @@ type saramaConsumer struct {
 
 // NewSaramaConsumer creates a new Consumer using sarama
 func NewSaramaConsumer(brokers []string, group string, config *cluster.Config) (Consumer, error) {
-	events := make(chan Event, defaultChannelBufferSize)
+	chsize := config.Config.ChannelBufferSize
+	if chsize == 0 {
+		chsize = defaultChannelBufferSize
+	}
+	events := make(chan Event, chsize)
 
 	g, err := newGroupConsumer(brokers, group, events, config)
 	if err != nil {


### PR DESCRIPTION
This PR lets the kafka wrapper simply use the default channel size from sarama. If one needs to change the channel size, one can create the consumer and pass it to goka via option.  