### PR TITLE
Bugfix/stalled partition recovery

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const (
+var (
 	tableSuffix = "-table"
 	loopSuffix  = "-loop"
 )

--- a/partition.go
+++ b/partition.go
@@ -2,7 +2,6 @@ package goka
 
 import (
 	"fmt"
-	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -359,7 +358,6 @@ func (p *partition) markRecovered(catchup bool) (err error) {
 		// mark storage as recovered -- this may take long
 		if err = p.st.MarkRecovered(); err != nil {
 			close(done)
-			log.Printf("error here")
 			return
 		}
 


### PR DESCRIPTION
* temporary make the graph-constants variables to be able to overwrite them via compiler-flag
* bugfix markRecovery after Catchup
* bugfix stalled-marked-partitions after recovery