### PR TITLE
add restartable view support

### DIFF
--- a/once.go
+++ b/once.go
@@ -1,0 +1,14 @@
+package goka
+
+import "sync"
+
+type once struct {
+	once sync.Once
+	err  error
+}
+
+// Do runs only once and always return the same error.
+func (o *once) Do(f func() error) error {
+	o.once.Do(func() { o.err = f() })
+	return o.err
+}

--- a/once_test.go
+++ b/once_test.go
@@ -1,0 +1,19 @@
+package goka
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/facebookgo/ensure"
+)
+
+func TestOnce_Do(t *testing.T) {
+	var o once
+
+	err := o.Do(func() error { return errors.New("some error") })
+	ensure.NotNil(t, err)
+
+	err2 := o.Do(func() error { return nil })
+	ensure.NotNil(t, err2)
+	ensure.DeepEqual(t, err, err2)
+}

--- a/options.go
+++ b/options.go
@@ -207,6 +207,7 @@ type voptions struct {
 	updateCallback       UpdateCallback
 	partitionChannelSize int
 	hasher               func() hash.Hash32
+	restartable          bool
 
 	builders struct {
 		storage  storage.Builder
@@ -272,6 +273,15 @@ func WithViewHasher(hasher func() hash.Hash32) ViewOption {
 func WithViewClientID(clientID string) ViewOption {
 	return func(o *voptions) {
 		o.clientID = clientID
+	}
+}
+
+// WithViewRestartable defines the view can be restarted, even when Start()
+// returns errors. If the view is restartable, the client must call Stop() to
+// release all resources.
+func WithViewRestartable() ViewOption {
+	return func(o *voptions) {
+		o.restartable = true
 	}
 }
 

--- a/partition_test.go
+++ b/partition_test.go
@@ -85,11 +85,9 @@ func TestPartition_startStateful(t *testing.T) {
 	p := newPartition(logger.Default(), topic, nil, newStorageProxy(st, 0, nil), proxy, defaultPartitionChannelSize)
 
 	gomock.InOrder(
-		st.EXPECT().Open().Return(nil),
 		st.EXPECT().GetOffset(int64(-2)).Return(offset, nil),
 		proxy.EXPECT().Add(topic, int64(offset)),
 		proxy.EXPECT().Remove(topic),
-		st.EXPECT().Close().Return(nil),
 		proxy.EXPECT().Stop(),
 	)
 	go func() {
@@ -254,13 +252,11 @@ func TestPartition_runStateful(t *testing.T) {
 	p := newPartition(logger.Default(), topic, consume, newStorageProxy(st, 0, nil), proxy, 0)
 
 	gomock.InOrder(
-		st.EXPECT().Open().Return(nil),
 		st.EXPECT().GetOffset(int64(-2)).Return(int64(offset), nil),
 		proxy.EXPECT().Add(topic, offset),
 		st.EXPECT().MarkRecovered(),
 		proxy.EXPECT().Remove(topic),
 		proxy.EXPECT().AddGroup(),
-		st.EXPECT().Close().Return(nil),
 		proxy.EXPECT().Stop(),
 	)
 
@@ -337,13 +333,11 @@ func TestPartition_runStatefulWithError(t *testing.T) {
 	p := newPartition(logger.Default(), topic, consume, newStorageProxy(st, 0, nil), proxy, defaultPartitionChannelSize)
 
 	gomock.InOrder(
-		st.EXPECT().Open().Return(nil),
 		st.EXPECT().GetOffset(int64(-2)).Return(int64(offset), nil),
 		proxy.EXPECT().Add(topic, offset),
 		st.EXPECT().MarkRecovered(),
 		proxy.EXPECT().Remove(topic),
 		proxy.EXPECT().AddGroup(),
-		st.EXPECT().Close().Return(nil),
 		proxy.EXPECT().Stop(),
 	)
 
@@ -415,7 +409,6 @@ func TestPartition_loadStateful(t *testing.T) {
 	p := newPartition(logger.Default(), topic, consume, newStorageProxy(st, 0, DefaultUpdate), proxy, defaultPartitionChannelSize)
 
 	gomock.InOrder(
-		st.EXPECT().Open().Return(nil),
 		st.EXPECT().GetOffset(int64(-2)).Return(int64(offset), nil),
 		proxy.EXPECT().Add(topic, offset),
 		st.EXPECT().Set(key, value),
@@ -423,7 +416,6 @@ func TestPartition_loadStateful(t *testing.T) {
 		st.EXPECT().MarkRecovered(),
 		proxy.EXPECT().Remove(topic),
 		proxy.EXPECT().AddGroup(),
-		st.EXPECT().Close().Return(nil),
 		proxy.EXPECT().Stop(),
 	)
 
@@ -497,11 +489,9 @@ func TestPartition_loadStatefulWithError(t *testing.T) {
 	p := newPartition(logger.Default(), topic, nil, newStorageProxy(st, 0, update), proxy, 0)
 
 	gomock.InOrder(
-		st.EXPECT().Open().Return(nil),
 		st.EXPECT().GetOffset(int64(-2)).Return(int64(offset), nil),
 		proxy.EXPECT().Add(topic, offset),
 		proxy.EXPECT().Remove(topic),
-		st.EXPECT().Close().Return(nil),
 		proxy.EXPECT().Stop(),
 	)
 
@@ -531,13 +521,11 @@ func TestPartition_loadStatefulWithError(t *testing.T) {
 	p = newPartition(logger.Default(), topic, nil, newStorageProxy(st, 0, DefaultUpdate), proxy, 0)
 
 	gomock.InOrder(
-		st.EXPECT().Open().Return(nil),
 		st.EXPECT().GetOffset(int64(-2)).Return(int64(offset), nil),
 		proxy.EXPECT().Add(topic, offset),
 		st.EXPECT().Set(key, value),
 		st.EXPECT().SetOffset(int64(offset)).Return(errors.New("some error")),
 		proxy.EXPECT().Remove(topic),
-		st.EXPECT().Close().Return(nil),
 		proxy.EXPECT().Stop(),
 	)
 
@@ -567,9 +555,7 @@ func TestPartition_loadStatefulWithError(t *testing.T) {
 	p = newPartition(logger.Default(), topic, nil, newStorageProxy(st, 0, nil), proxy, 0)
 
 	gomock.InOrder(
-		st.EXPECT().Open().Return(nil),
 		st.EXPECT().GetOffset(int64(-2)).Return(int64(0), errors.New("some error")),
-		st.EXPECT().Close().Return(nil),
 		proxy.EXPECT().Stop(),
 	)
 
@@ -607,10 +593,8 @@ func TestPartition_loadStatefulWithErrorAddRemovePartition(t *testing.T) {
 	p := newPartition(logger.Default(), topic, nil, newStorageProxy(st, 0, DefaultUpdate), proxy, 0)
 
 	gomock.InOrder(
-		st.EXPECT().Open().Return(nil),
 		st.EXPECT().GetOffset(int64(-2)).Return(int64(offset), nil),
 		proxy.EXPECT().Add(topic, offset).Return(errors.New("some error adding partition")),
-		st.EXPECT().Close().Return(nil),
 		proxy.EXPECT().Stop(),
 	)
 
@@ -632,11 +616,9 @@ func TestPartition_loadStatefulWithErrorAddRemovePartition(t *testing.T) {
 	p = newPartition(logger.Default(), topic, nil, newStorageProxy(st, 0, update), proxy, 0)
 
 	gomock.InOrder(
-		st.EXPECT().Open().Return(nil),
 		st.EXPECT().GetOffset(int64(-2)).Return(int64(offset), nil),
 		proxy.EXPECT().Add(topic, offset).Return(nil),
 		proxy.EXPECT().Remove(topic).Return(errors.New("error while removing partition")),
-		st.EXPECT().Close().Return(nil),
 		proxy.EXPECT().Stop(),
 	)
 
@@ -690,7 +672,6 @@ func TestPartition_catchupStateful(t *testing.T) {
 	p := newPartition(logger.Default(), topic, nil, newStorageProxy(st, 0, update), proxy, 0)
 
 	gomock.InOrder(
-		st.EXPECT().Open().Return(nil),
 		st.EXPECT().GetOffset(int64(-2)).Return(int64(offset), nil),
 		proxy.EXPECT().Add(topic, offset),
 		st.EXPECT().Set(key, value),
@@ -703,7 +684,6 @@ func TestPartition_catchupStateful(t *testing.T) {
 		st.EXPECT().Set(key, value),
 		st.EXPECT().SetOffset(offset+2).Return(nil),
 		proxy.EXPECT().Remove(topic),
-		st.EXPECT().Close().Return(nil),
 		proxy.EXPECT().Stop(),
 	)
 
@@ -809,7 +789,6 @@ func TestPartition_catchupStatefulWithError(t *testing.T) {
 	p := newPartition(logger.Default(), topic, nil, newStorageProxy(st, 0, update), proxy, 0)
 
 	gomock.InOrder(
-		st.EXPECT().Open().Return(nil),
 		st.EXPECT().GetOffset(int64(-2)).Return(int64(offset), nil),
 		proxy.EXPECT().Add(topic, offset),
 		st.EXPECT().Set(key, value),
@@ -820,7 +799,6 @@ func TestPartition_catchupStatefulWithError(t *testing.T) {
 		st.EXPECT().MarkRecovered(),
 		proxy.EXPECT().Add(topic, offset+2),
 		proxy.EXPECT().Remove(topic),
-		st.EXPECT().Close().Return(nil),
 		proxy.EXPECT().Stop(),
 	)
 

--- a/proxy.go
+++ b/proxy.go
@@ -97,16 +97,33 @@ type storageProxy struct {
 	partition int32
 	stateless bool
 	update    UpdateCallback
+
+	openedOnce once
+	closedOnce once
 }
 
-func (s storageProxy) Update(k string, v []byte) error {
+func (s *storageProxy) Open() error {
+	if s == nil {
+		return nil
+	}
+	return s.openedOnce.Do(s.Storage.Open)
+}
+
+func (s *storageProxy) Close() error {
+	if s == nil {
+		return nil
+	}
+	return s.closedOnce.Do(s.Storage.Close)
+}
+
+func (s *storageProxy) Update(k string, v []byte) error {
 	return s.update(s.Storage, s.partition, k, v)
 }
 
-func (s storageProxy) Stateless() bool {
+func (s *storageProxy) Stateless() bool {
 	return s.stateless
 }
 
-func (s storageProxy) MarkRecovered() error {
+func (s *storageProxy) MarkRecovered() error {
 	return s.Storage.MarkRecovered()
 }


### PR DESCRIPTION
This PR resolves #102.

If one starts a view with the option`goka.WithViewRestartable()`, the view may be restarted or used, eg, by calling `Get()` and `Recovered()`, `Iterator()`, etc. To release all resources, ie, close the underlying local storage, one must call `Stop()` when using the `Restartable()` option.