### PR TITLE
Allow non-copartitioned lookup tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Goka relies on Kafka for message passing, fault-tolerant state storage and workl
 
 * **Views** are local caches of a complete group table. Views provide read-only access to the group tables and can be used to provide external services for example through a gRPC interface.
 
-* **Local storage** keeps a local copy of the group table partitions to speedup recovery and reduce memory utilization. By default, the local storage uses [LevelDB](https://github.com/syndtr/goleveldb), but in-memory map and [Redis-based storage](tree/master/storage/redis) are also available.
+* **Local storage** keeps a local copy of the group table partitions to speedup recovery and reduce memory utilization. By default, the local storage uses [LevelDB](https://github.com/syndtr/goleveldb), but in-memory map and [Redis-based storage](https://github.com/lovoo/goka/tree/master/storage/redis) are also available.
 
 
 ## Get Started

--- a/graph.go
+++ b/graph.go
@@ -72,6 +72,11 @@ func (gg *GroupGraph) inputs() Edges {
 	return append(append(gg.inputStreams, gg.inputTables...), gg.crossTables...)
 }
 
+// copartitioned returns all copartitioned topics (joint tables and input streams)
+func (gg *GroupGraph) copartitioned() Edges {
+	return append(gg.inputStreams, gg.inputTables...)
+}
+
 func (gg *GroupGraph) codec(topic string) Codec {
 	return gg.codecs[topic]
 }

--- a/processor.go
+++ b/processor.go
@@ -148,7 +148,7 @@ func prepareTopics(brokers []string, gg *GroupGraph, opts *poptions) (npar int, 
 	}()
 
 	// check co-partitioned (external) topics have the same number of partitions
-	npar, err = copartitioned(tm, gg.inputs().Topics())
+	npar, err = ensureCopartitioned(tm, gg.copartitioned().Topics())
 	if err != nil {
 		return 0, err
 	}
@@ -174,7 +174,7 @@ func prepareTopics(brokers []string, gg *GroupGraph, opts *poptions) (npar int, 
 
 // returns the number of partitions the topics have, and an error if topics are
 // not copartitionea.
-func copartitioned(tm kafka.TopicManager, topics []string) (int, error) {
+func ensureCopartitioned(tm kafka.TopicManager, topics []string) (int, error) {
 	var npar int
 	for _, topic := range topics {
 		partitions, err := tm.Partitions(topic)


### PR DESCRIPTION
This PR allows lookup tables to have a different number of partitions than the group table. Resolves #109.