### PR TITLE
Adding TopicManagerBuilderWithConfig to allow custom Sarama config

### DIFF
--- a/kafka/builders.go
+++ b/kafka/builders.go
@@ -52,7 +52,15 @@ type TopicManagerBuilder func(brokers []string) (TopicManager, error)
 // DefaultTopicManagerBuilder creates TopicManager using the Sarama library.
 // This topic manager cannot create topics.
 func DefaultTopicManagerBuilder(brokers []string) (TopicManager, error) {
-	return NewSaramaTopicManager(brokers)
+	return NewSaramaTopicManager(brokers, sarama.NewConfig())
+}
+
+// TopicManagerBuilderWithConfig creates TopicManager using the Sarama library.
+// This topic manager cannot create topics.
+func TopicManagerBuilderWithConfig(config *cluster.Config) TopicManagerBuilder {
+	return func(brokers []string) (TopicManager, error) {
+		return NewSaramaTopicManager(brokers, &config.Config)
+	}
 }
 
 // ZKTopicManagerBuilder creates a TopicManager that connects with ZooKeeper to

--- a/kafka/topic_manager.go
+++ b/kafka/topic_manager.go
@@ -31,8 +31,7 @@ type saramaTopicManager struct {
 }
 
 // NewSaramaTopicManager creates a new topic manager using the sarama library
-func NewSaramaTopicManager(brokers []string) (TopicManager, error) {
-	config := sarama.NewConfig()
+func NewSaramaTopicManager(brokers []string, config *sarama.Config) (TopicManager, error) {
 	client, err := sarama.NewClient(brokers, config)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating the kafka client: %v", err)


### PR DESCRIPTION
I've been playing with goka and found that there was no nice way to configure the sarama connection for the topicmanagerbuilder.

This became a problem when trying to configure an SSL connection to Kafka for a Goka View. With this PR, the following code works:

```
func NewConfig(certLocation string) *cluster.Config {
	caCert, err := ioutil.ReadFile(certLocation)
	if err != nil {
		panic("Unable to read ROOT CA cert")
	}

	caCertPool := x509.NewCertPool()
	caCertPool.AppendCertsFromPEM([]byte(caCert))

	config := kafka.NewConfig()
	config.Net.TLS.Enable = true
	config.Net.TLS.Config = &tls.Config{
		RootCAs:            caCertPool,
		InsecureSkipVerify: true,
	}

	return config
}

func Run(brokers []string, certPath string, group goka.Group) {
	c := NewConfig(certPath)

	view, err := goka.NewView(
		brokers,
		goka.GroupTable(group),
		new(customer.Codec),
		goka.WithViewTopicManagerBuilder(
			kafka.TopicManagerBuilderWithConfig(c),
		),
		goka.WithViewConsumerBuilder(
			kafka.ConsumerBuilderWithConfig(c),
		),
	)

     // Do Stuff!
}
```