### PR TITLE
fix only first two iters checked

### DIFF
--- a/storage/multi_iterator.go
+++ b/storage/multi_iterator.go
@@ -20,9 +20,7 @@ func (m *multiIterator) Next() (next bool) {
 		if next {
 			break
 		}
-		m.current++
 	}
-
 	return next
 }
 

--- a/storage/multi_iterator.go
+++ b/storage/multi_iterator.go
@@ -14,11 +14,13 @@ func NewMultiIterator(iters []Iterator) Iterator {
 	return &multiIterator{current: 0, iters: iters}
 }
 
-func (m *multiIterator) Next() bool {
-	next := m.iters[m.current].Next()
-	if !next && len(m.iters)-1 > m.current {
-		m.current++
+func (m *multiIterator) Next() (next bool) {
+	for ; m.current < len(m.iters); m.current++ {
 		next = m.iters[m.current].Next()
+		if next {
+			break
+		}
+		m.current++
 	}
 
 	return next

--- a/storage/multi_iterator_test.go
+++ b/storage/multi_iterator_test.go
@@ -89,18 +89,18 @@ func TestMultiIteratorMixedValues(t *testing.T) {
 	var expected []string
 	n := 0
 
-	// first storage has 0 values
+	// first storage has two values
 	storages[0] = NewMemory()
-
-	// second storage has two values
-	storages[1] = NewMemory()
 	for i := 0; i < 2; i++ {
 		key := fmt.Sprintf("key-%d", n)
 		val := fmt.Sprintf("value-%d", n)
 		n++
 		expected = append(expected, val)
-		storages[1].Set(key, []byte(val))
+		storages[0].Set(key, []byte(val))
 	}
+
+	// second storage has 0 values
+	storages[1] = NewMemory()
 
 	// third storage has three values
 	storages[2] = NewMemory()

--- a/storage/multi_iterator_test.go
+++ b/storage/multi_iterator_test.go
@@ -58,9 +58,7 @@ func TestMultiIterator(t *testing.T) {
 
 func TestMultiIteratorOneValue(t *testing.T) {
 	numStorages := 3
-
 	storages := make([]Storage, numStorages)
-	expected := map[string]string{}
 
 	// first two storages are empty
 	storages[0] = NewMemory()
@@ -70,7 +68,6 @@ func TestMultiIteratorOneValue(t *testing.T) {
 	storages[numStorages-1] = NewMemory()
 	key := fmt.Sprintf("storage-%d", numStorages-1)
 	val := fmt.Sprintf("value-%d", 1)
-	expected[key] = val
 	storages[numStorages-1].Set(key, []byte(val))
 
 	iters := make([]Iterator, len(storages))


### PR DESCRIPTION
Only the first two iterators are checked, this is a bug that only shows when there are more than 2 partitions.