### PR TITLE
add Context() method to goka.Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,6 +1,7 @@
 package goka
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -60,11 +61,16 @@ type Context interface {
 
 	// Fail stops execution and shuts down the processor
 	Fail(err error)
+
+	// Context returns the underlying context used to start the processor or a
+	// subcontext.
+	Context() context.Context
 }
 
 type emitter func(topic string, key string, value []byte) *kafka.Promise
 
 type cbContext struct {
+	ctx   context.Context
 	graph *GroupGraph
 
 	commit  func()
@@ -345,4 +351,8 @@ func (ctx *cbContext) tryCommit(err error) {
 // Fail stops execution and shuts down the processor
 func (ctx *cbContext) Fail(err error) {
 	panic(err)
+}
+
+func (ctx *cbContext) Context() context.Context {
+	return ctx.ctx
 }

--- a/processor_test.go
+++ b/processor_test.go
@@ -249,6 +249,8 @@ func TestProcessor_process(t *testing.T) {
 
 		consumer: consumer,
 		producer: producer,
+
+		ctx: context.Background(),
 	}
 
 	// no emits
@@ -344,6 +346,7 @@ func TestProcessor_processFail(t *testing.T) {
 
 			errors: new(multierr.Errors),
 			cancel: func() { close(canceled) },
+			ctx:    context.Background(),
 		}
 
 		p.opts.log = logger.Default()


### PR DESCRIPTION
This resolves part of #151.

Next step should be to add a way to replace the context as @burdiyan suggested.