### PR TITLE
#188 tester does not consume message produced by emitter only

### DIFF
--- a/tester/tester.go
+++ b/tester/tester.go
@@ -292,6 +292,13 @@ func (km *Tester) ConsumeData(topic string, key string, data []byte) {
 	km.waitForConsumers()
 }
 
+// Flush flushes all pending messages in the tester queues.
+// pending messages can occur when an emitter pushes messages directly to the tester
+// without using the tester's `Consume` - method.
+func (km *Tester) Flush() {
+	km.waitForConsumers()
+}
+
 func (km *Tester) pushMessage(topic string, key string, data []byte) {
 	km.queuedMessages = append(km.queuedMessages, &queuedMessage{topic: topic, key: key, value: data})
 }

--- a/tester/tester_test.go
+++ b/tester/tester_test.go
@@ -498,3 +498,18 @@ func Test_ManyConsume(t *testing.T) {
 		t.Fatalf("did not receive all messages")
 	}
 }
+
+func TestEmitter(t *testing.T) {
+	gkt := New(t)
+
+	em, _ := goka.NewEmitter(nil, "test", new(codec.String), goka.WithEmitterTester(gkt))
+	est := gkt.NewQueueTracker("test")
+
+	em.Emit("key", "value")
+	gkt.Flush()
+
+	_, _, ok := est.Next()
+	if !ok {
+		t.Errorf("No message emitted")
+	}
+}


### PR DESCRIPTION
This PR provides a workaround for #188 