### PR TITLE
protect storage writes

### DIFF
--- a/tester/tester.go
+++ b/tester/tester.go
@@ -232,9 +232,12 @@ func (km *Tester) EmitterProducerBuilder() kafka.ProducerBuilder {
 // to a processor
 func (km *Tester) StorageBuilder() storage.Builder {
 	return func(topic string, partition int32) (storage.Storage, error) {
+		km.mStorages.RLock()
 		if st, exists := km.storages[topic]; exists {
+			km.mStorages.RUnlock()
 			return st, nil
 		}
+		km.mStorages.RUnlock()
 		st := storage.NewMemory()
 		km.mStorages.Lock()
 		km.storages[topic] = st
@@ -326,7 +329,9 @@ func (km *Tester) TableValue(table goka.Table, key string) interface{} {
 	km.waitStartup()
 
 	topic := string(table)
+	km.mStorages.RLock()
 	st, exists := km.storages[topic]
+	km.mStorages.RUnlock()
 	if !exists {
 		panic(fmt.Errorf("topic %s does not exist", topic))
 	}
@@ -351,7 +356,9 @@ func (km *Tester) SetTableValue(table goka.Table, key string, value interface{})
 	logger.Printf("setting value is not implemented yet.")
 
 	topic := string(table)
+	km.mStorages.RLock()
 	st, exists := km.storages[topic]
+	km.mStorages.RUnlock()
 	if !exists {
 		panic(fmt.Errorf("storage for topic %s does not exist", topic))
 	}
@@ -373,6 +380,7 @@ func (km *Tester) ReplaceEmitHandler(emitter EmitHandler) {
 
 // ClearValues resets all table values
 func (km *Tester) ClearValues() {
+	km.mStorages.Lock()
 	for topic, st := range km.storages {
 		logger.Printf("clearing all values from storage for topic %s", topic)
 		it, _ := st.Iterator()
@@ -380,6 +388,7 @@ func (km *Tester) ClearValues() {
 			st.Delete(string(it.Key()))
 		}
 	}
+	km.mStorages.Unlock()
 }
 
 type topicMgrMock struct {

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -55,6 +55,7 @@ type Tester struct {
 	codecs      map[string]goka.Codec
 	topicQueues map[string]*queue
 	mQueues     sync.RWMutex
+	mStorages   sync.RWMutex
 
 	queuedMessages []*queuedMessage
 }
@@ -235,7 +236,9 @@ func (km *Tester) StorageBuilder() storage.Builder {
 			return st, nil
 		}
 		st := storage.NewMemory()
+		km.mStorages.Lock()
 		km.storages[topic] = st
+		km.mStorages.Unlock()
 		return st, nil
 	}
 }


### PR DESCRIPTION
We are creating multiple processors in a short time in our tests and they are failing sometimes because of concurrent map writes. We think we traced the problem to this point.