### PR TITLE
adding custom logger option

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/lovoo/goka/logger"
+
 	"github.com/lovoo/goka/kafka"
 )
 
@@ -19,6 +21,11 @@ type Emitter struct {
 
 // NewEmitter creates a new emitter using passed brokers, topic, codec and possibly options.
 func NewEmitter(brokers []string, topic Stream, codec Codec, options ...EmitterOption) (*Emitter, error) {
+	return NewEmitterWithLogger(brokers, topic, codec, logger.Default(), options...)
+}
+
+// NewEmitterWithLogger creates a new emitter using passed brokers, topic, codec, a custom logger and possibly options.
+func NewEmitterWithLogger(brokers []string, topic Stream, codec Codec, logger logger.Logger, options ...EmitterOption) (*Emitter, error) {
 	options = append(
 		// default options comes first
 		[]EmitterOption{},
@@ -29,7 +36,7 @@ func NewEmitter(brokers []string, topic Stream, codec Codec, options ...EmitterO
 
 	opts := new(eoptions)
 
-	err := opts.applyOptions(topic, codec, options...)
+	err := opts.applyOptionsWithLogger(topic, codec, logger, options...)
 	if err != nil {
 		return nil, fmt.Errorf(errApplyOptions, err)
 	}

--- a/options.go
+++ b/options.go
@@ -51,7 +51,6 @@ func DefaultUpdate(s storage.Storage, partition int32, key string, value []byte)
 	return s.Set(key, value)
 }
 
-
 // DefaultRebalance is the default callback when a new partition assignment is received.
 // DefaultRebalance can be used in the function passed to WithRebalanceCallback.
 func DefaultRebalance(a kafka.Assignment) {}
@@ -211,8 +210,12 @@ func WithTester(t Tester) ProcessorOption {
 }
 
 func (opt *poptions) applyOptions(gg *GroupGraph, opts ...ProcessorOption) error {
+	return opt.applyOptionsWithLogger(gg, logger.Default(), opts...)
+}
+
+func (opt *poptions) applyOptionsWithLogger(gg *GroupGraph, logger logger.Logger, opts ...ProcessorOption) error {
 	opt.clientID = defaultClientID
-	opt.log = logger.Default()
+	opt.log = logger
 	opt.hasher = DefaultHasher()
 
 	for _, o := range opts {
@@ -349,8 +352,12 @@ func WithViewTester(t Tester) ViewOption {
 }
 
 func (opt *voptions) applyOptions(topic Table, codec Codec, opts ...ViewOption) error {
+	return opt.applyOptionsWithLogger(topic, codec, logger.Default(), opts...)
+}
+
+func (opt *voptions) applyOptionsWithLogger(topic Table, codec Codec, logger logger.Logger, opts ...ViewOption) error {
 	opt.clientID = defaultClientID
-	opt.log = logger.Default()
+	opt.log = logger
 	opt.hasher = DefaultHasher()
 
 	for _, o := range opts {
@@ -435,9 +442,14 @@ func WithEmitterTester(t Tester) EmitterOption {
 		t.RegisterEmitter(topic, codec)
 	}
 }
+
 func (opt *eoptions) applyOptions(topic Stream, codec Codec, opts ...EmitterOption) error {
+	return opt.applyOptionsWithLogger(topic, codec, logger.Default(), opts...)
+}
+
+func (opt *eoptions) applyOptionsWithLogger(topic Stream, codec Codec, logger logger.Logger, opts ...EmitterOption) error {
 	opt.clientID = defaultClientID
-	opt.log = logger.Default()
+	opt.log = logger
 	opt.hasher = DefaultHasher()
 
 	for _, o := range opts {

--- a/view.go
+++ b/view.go
@@ -27,10 +27,15 @@ type View struct {
 
 // NewView creates a new View object from a group.
 func NewView(brokers []string, topic Table, codec Codec, options ...ViewOption) (*View, error) {
+	return NewViewWithLogger(brokers, topic, codec, logger.Default(), options...)
+}
+
+// NewViewWithLogger creates a new View object from a group with a custom ,logger.
+func NewViewWithLogger(brokers []string, topic Table, codec Codec, logger logger.Logger, options ...ViewOption) (*View, error) {
 	options = append(
 		// default options comes first
 		[]ViewOption{
-			WithViewLogger(logger.Default()),
+			WithViewLogger(logger),
 			WithViewCallback(DefaultUpdate),
 			WithViewPartitionChannelSize(defaultPartitionChannelSize),
 			WithViewStorageBuilder(storage.DefaultBuilder(DefaultViewStoragePath())),
@@ -42,7 +47,7 @@ func NewView(brokers []string, topic Table, codec Codec, options ...ViewOption) 
 
 	// figure out how many partitions the group has
 	opts := new(voptions)
-	err := opts.applyOptions(topic, codec, options...)
+	err := opts.applyOptionsWithLogger(topic, codec, logger, options...)
 	if err != nil {
 		return nil, fmt.Errorf("Error applying user-defined options: %v", err)
 	}

--- a/web/index/index.go
+++ b/web/index/index.go
@@ -28,9 +28,15 @@ type ComponentPathProvider interface {
 	BasePath() string
 }
 
+// NewServer creates a new Server with the default Logger
 func NewServer(basePath string, router *mux.Router) *Server {
+	return NewServerWithLogger(basePath, router, logger.Default())
+}
+
+// NewServerWithLogger creates a new Server with a custom logger
+func NewServerWithLogger(basePath string, router *mux.Router, logger logger.Logger) *Server {
 	srv := &Server{
-		log:      logger.Default(),
+		log:      logger,
 		basePath: basePath,
 	}
 

--- a/web/monitor/monitoring.go
+++ b/web/monitor/monitoring.go
@@ -28,10 +28,15 @@ type Server struct {
 	processors []*goka.Processor
 }
 
-// NewServer creates a new Server
+// NewServer creates a new server with the default logger
 func NewServer(basePath string, router *mux.Router, opts ...Option) *Server {
+	return NewServerWithLogger(basePath, router, logger.Default(), opts...)
+}
+
+// NewServerWithLogger creates a new Server with a custom logger
+func NewServerWithLogger(basePath string, router *mux.Router, logger logger.Logger, opts ...Option) *Server {
 	srv := &Server{
-		log:      logger.Default(),
+		log:      logger,
 		basePath: basePath,
 	}
 

--- a/web/query/query.go
+++ b/web/query/query.go
@@ -53,10 +53,15 @@ type Server struct {
 	humanizer Humanizer
 }
 
-// NewServer creates a server with the given options.
+// NewServer creates a server with the default logger and the given options
 func NewServer(basePath string, router *mux.Router, opts ...Option) *Server {
+	return NewServerWithLogger(basePath, router, logger.Default(), opts...)
+}
+
+// NewServerWithLogger creates a server with the given options.
+func NewServerWithLogger(basePath string, router *mux.Router, logger logger.Logger, opts ...Option) *Server {
 	srv := &Server{
-		log:       logger.Default(),
+		log:       logger,
 		basePath:  basePath,
 		loader:    &templates.BinLoader{},
 		sources:   make(map[string]goka.Getter),


### PR DESCRIPTION
Added the ability to use a custom logger implemented according to the goka logger interface.
This shouldn't break the current usage, since functions with the default logger stay the same.