### PR TITLE
Adding header on message

### DIFF
--- a/context.go
+++ b/context.go
@@ -33,6 +33,9 @@ type Context interface {
 	// Value returns the value of the key in the group table.
 	Value() interface{}
 
+	// Headers returns the headers of the input message
+	Headers() map[string][]byte
+
 	// SetValue updates the value of the key in the group table.
 	SetValue(value interface{})
 
@@ -194,6 +197,10 @@ func (ctx *cbContext) Offset() int64 {
 
 func (ctx *cbContext) Partition() int32 {
 	return ctx.msg.Partition
+}
+
+func (ctx *cbContext) Headers() map[string][]byte {
+	return ctx.msg.Header
 }
 
 func (ctx *cbContext) Join(topic Table) interface{} {

--- a/kafka/confluent/confluent.go
+++ b/kafka/confluent/confluent.go
@@ -161,6 +161,11 @@ func (c *confluent) run() {
 					partition = e.TopicPartition.Partition
 				)
 
+				headers := make(map[string][]byte)
+				for _, header := range e.Headers {
+					headers[header.Key] = header.Value
+				}
+
 				c.events <- &kafka.Message{
 					Topic:     topic,
 					Partition: partition,
@@ -168,6 +173,7 @@ func (c *confluent) run() {
 					Key:       string(e.Key),
 					Value:     e.Value,
 					Timestamp: e.Timestamp,
+					Header:    headers,
 				}
 
 			case rdkafka.PartitionEOF:

--- a/kafka/event.go
+++ b/kafka/event.go
@@ -48,6 +48,7 @@ type Message struct {
 	Partition int32
 	Offset    int64
 	Timestamp time.Time
+	Header    map[string][]byte
 
 	Key   string
 	Value []byte

--- a/kafka/group_consumer.go
+++ b/kafka/group_consumer.go
@@ -211,6 +211,12 @@ func (c *groupConsumer) waitForMessages() bool {
 				return false
 			}
 		case msg := <-c.consumer.Messages():
+
+			headers := make(map[string][]byte)
+			for _, header := range msg.Headers {
+				headers[string(header.Key)] = header.Value
+			}
+
 			select {
 			case c.events <- &Message{
 				Topic:     msg.Topic,
@@ -219,6 +225,7 @@ func (c *groupConsumer) waitForMessages() bool {
 				Timestamp: msg.Timestamp,
 				Key:       string(msg.Key),
 				Value:     msg.Value,
+				Header:    headers,
 			}:
 			case <-c.stop:
 				return false

--- a/kafka/group_consumer_test.go
+++ b/kafka/group_consumer_test.go
@@ -255,6 +255,7 @@ func TestGroupConsumer_GroupConsumeMessages(t *testing.T) {
 		Offset:    0,
 		Key:       string(key),
 		Value:     value,
+		Header:    make(map[string][]byte),
 	})
 
 	ensure.DeepEqual(t, c.partitionMap, map[int32]bool{
@@ -458,6 +459,7 @@ func TestGroupConsumer_GroupNotificationsAfterMessages(t *testing.T) {
 		Offset:    0,
 		Key:       string(key),
 		Value:     value,
+		Header:    make(map[string][]byte),
 	})
 
 	ensure.DeepEqual(t, c.partitionMap, map[int32]bool{
@@ -564,6 +566,7 @@ func TestGroupConsumer_GroupEmptyNotifications(t *testing.T) {
 		Offset:    0,
 		Key:       string(key),
 		Value:     value,
+		Header:    make(map[string][]byte),
 	})
 
 	ensure.DeepEqual(t, c.partitionMap, map[int32]bool{

--- a/kafka/simple_consumer.go
+++ b/kafka/simple_consumer.go
@@ -139,6 +139,12 @@ func (c *simpleConsumer) run(pc sarama.PartitionConsumer, topic string, partitio
 				// drained.
 				continue
 			}
+
+			headers := make(map[string][]byte)
+			for _, header := range m.Headers {
+				headers[string(header.Key)] = header.Value
+			}
+
 			select {
 			case c.events <- &Message{
 				Topic:     m.Topic,
@@ -147,6 +153,7 @@ func (c *simpleConsumer) run(pc sarama.PartitionConsumer, topic string, partitio
 				Key:       string(m.Key),
 				Value:     m.Value,
 				Timestamp: m.Timestamp,
+				Header:    headers,
 			}:
 			case <-c.dying:
 				return

--- a/partition.go
+++ b/partition.go
@@ -134,6 +134,7 @@ func newMessage(ev *kafka.Message) *message {
 		Timestamp: ev.Timestamp,
 		Data:      ev.Value,
 		Key:       ev.Key,
+		Header:    ev.Header,
 	}
 }
 

--- a/processor.go
+++ b/processor.go
@@ -47,6 +47,7 @@ type message struct {
 	Partition int32
 	Offset    int64
 	Timestamp time.Time
+	Header    map[string][]byte
 }
 
 // ProcessCallback function is called for every message received by the
@@ -655,14 +656,11 @@ func (g *Processor) rebalance(errg *multierr.ErrGroup, ctx context.Context, part
 	errs := new(multierr.Errors)
 	g.opts.log.Printf("Processor: rebalancing: %+v", partitions)
 
-
 	// callback the new partition assignment
 	g.opts.rebalanceCallback(partitions)
 
-
 	g.m.Lock()
 	defer g.m.Unlock()
-
 
 	for id := range partitions {
 		// create partition views


### PR DESCRIPTION
I changed the message to contain the headers

only work if set the `client.Version` to 0.11+ on samara client 

Example processor with `config.Version` 2.2.0
```
p, err := goka.NewProcessor(
	brokers,
	g,
	goka.WithConsumerBuilder(func(brokers []string, group, clientID string) (consumer kafka.Consumer, err error) {
		config := kafka.NewConfig()
		config.ClientID = clientID
		config.Version = sarama.V2_2_0_0
		return kafka.NewSaramaConsumer(brokers, group, config)
	}),
)
```

Your can get the headers from context with `ctx.Headers()`