### PR TITLE
Add Backoff when restartable CatchupForever is executed

### DIFF
--- a/builders.go
+++ b/builders.go
@@ -2,6 +2,7 @@ package goka
 
 import (
 	"hash"
+	"time"
 
 	"github.com/Shopify/sarama"
 )
@@ -87,4 +88,12 @@ func SaramaConsumerBuilderWithConfig(config *sarama.Config) SaramaConsumerBuilde
 		config.ClientID = clientID
 		return sarama.NewConsumer(brokers, config)
 	}
+}
+
+// BackoffBuilder creates a backoff
+type BackoffBuilder func() (Backoff, error)
+
+// DefaultBackoffBuilder returnes a simpleBackoff with 10 second steps
+func DefaultBackoffBuilder() (Backoff, error) {
+	return NewSimpleBackoff(time.Second * 10), nil
 }

--- a/partition_table_test.go
+++ b/partition_table_test.go
@@ -32,6 +32,8 @@ func defaultPT(
 		updateCallback,
 		bm.getStorageBuilder(),
 		logger.Default(),
+		NewSimpleBackoff(time.Second*10),
+		time.Minute,
 	), bm, ctrl
 }
 

--- a/processor.go
+++ b/processor.go
@@ -607,7 +607,11 @@ func (g *Processor) createPartitionProcessor(ctx context.Context, partition int3
 		return fmt.Errorf("processor [%s]: partition %d already exists", g.graph.Group(), partition)
 	}
 
-	pproc := newPartitionProcessor(partition, g.graph, session, g.log, g.opts, g.lookupTables, g.saramaConsumer, g.producer, g.tmgr)
+	backoff, err := g.opts.builders.backoff()
+	if err != nil {
+		return fmt.Errorf("processor [%s]: could not build backoff handler: %v", g.graph.Group(), err)
+	}
+	pproc := newPartitionProcessor(partition, g.graph, session, g.log, g.opts, g.lookupTables, g.saramaConsumer, g.producer, g.tmgr, backoff, g.opts.backoffResetTime)
 
 	g.partitions[partition] = pproc
 	return nil

--- a/simple_backoff.go
+++ b/simple_backoff.go
@@ -1,0 +1,25 @@
+package goka
+
+import "time"
+
+// NewSimpleBackoff returns a simple backoff waiting the
+// specified duration longer each iteration until reset.
+func NewSimpleBackoff(step time.Duration) Backoff {
+	return &simpleBackoff{
+		step: time.Second,
+	}
+}
+
+type simpleBackoff struct {
+	current time.Duration
+	step    time.Duration
+}
+
+func (b *simpleBackoff) Reset() {
+	b.current = time.Duration(0)
+}
+
+func (b *simpleBackoff) Duration() time.Duration {
+	b.current += b.step
+	return b.current
+}

--- a/simple_backoff_test.go
+++ b/simple_backoff_test.go
@@ -1,0 +1,26 @@
+package goka
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lovoo/goka/internal/test"
+)
+
+func TestSimpleBackoff(t *testing.T) {
+	t.Run("simple progression", func(t *testing.T) {
+		backoff := NewSimpleBackoff(time.Second)
+		for i := 0; i < 10; i++ {
+			test.AssertEqual(t, time.Duration(i+1)*time.Second, backoff.Duration())
+		}
+	})
+	t.Run("reset", func(t *testing.T) {
+		backoff := NewSimpleBackoff(time.Second)
+		for i := 0; i < 10; i++ {
+			if i%5 == 0 {
+				backoff.Reset()
+			}
+			test.AssertEqual(t, time.Duration(i%5+1)*time.Second, backoff.Duration())
+		}
+	})
+}

--- a/view.go
+++ b/view.go
@@ -115,6 +115,10 @@ func (v *View) createPartitions(brokers []string) (rerr error) {
 	}
 
 	for partID, p := range partitions {
+		backoff, err := v.opts.builders.backoff()
+		if err != nil {
+			return fmt.Errorf("Error creating backoff: %v", err)
+		}
 		v.partitions = append(v.partitions, newPartitionTable(v.topic,
 			p,
 			v.consumer,
@@ -122,6 +126,8 @@ func (v *View) createPartitions(brokers []string) (rerr error) {
 			v.opts.updateCallback,
 			v.opts.builders.storage,
 			v.log.Prefix(fmt.Sprintf("PartTable-%d", partID)),
+			backoff,
+			v.opts.backoffResetTime,
 		))
 	}
 

--- a/view_test.go
+++ b/view_test.go
@@ -83,6 +83,7 @@ func createTestView(t *testing.T, consumer sarama.Consumer) (*View, *builderMock
 	opts.builders.consumerSarama = func(brokers []string, clientID string) (sarama.Consumer, error) {
 		return consumer, nil
 	}
+	opts.builders.backoff = DefaultBackoffBuilder
 
 	view := &View{topic: viewTestTopic, opts: opts, log: opts.log}
 	return view, bm, ctrl
@@ -584,6 +585,8 @@ func TestView_Run(t *testing.T) {
 			updateCB,
 			bm.getStorageBuilder(),
 			logger.Default(),
+			NewSimpleBackoff(time.Second*10),
+			time.Minute,
 		)
 
 		pt.consumer = consumer
@@ -637,6 +640,8 @@ func TestView_Run(t *testing.T) {
 			updateCB,
 			bm.getStorageBuilder(),
 			logger.Default(),
+			NewSimpleBackoff(time.Second*10),
+			time.Minute,
 		)
 
 		pt.consumer = consumer


### PR DESCRIPTION
A customizable backoff is used when restarting the PartitionTables loading function. 
Options for the view and processor can be used to customize the reset timeout and set the backoff provider. 