### PR TITLE
Allow producer to set Kafka headers

### DIFF
--- a/mocks.go
+++ b/mocks.go
@@ -170,6 +170,20 @@ func (mr *MockProducerMockRecorder) Emit(arg0, arg1, arg2 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Emit", reflect.TypeOf((*MockProducer)(nil).Emit), arg0, arg1, arg2)
 }
 
+// EmitWithHeaders mocks base method
+func (m *MockProducer) EmitWithHeaders(arg0, arg1 string, arg2 []byte, arg3 map[string][]byte) *Promise {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EmitWithHeaders", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*Promise)
+	return ret0
+}
+
+// EmitWithHeaders indicates an expected call of EmitWithHeaders
+func (mr *MockProducerMockRecorder) EmitWithHeaders(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmitWithHeaders", reflect.TypeOf((*MockProducer)(nil).EmitWithHeaders), arg0, arg1, arg2, arg3)
+}
+
 // MockBroker is a mock of Broker interface
 type MockBroker struct {
 	ctrl     *gomock.Controller

--- a/tester/producer.go
+++ b/tester/producer.go
@@ -21,6 +21,13 @@ func newProducerMock(emitter emitHandler) *producerMock {
 // Emit emits messages to arbitrary topics.
 // The mock simply forwards the emit to the KafkaMock which takes care of queueing calls
 // to handled topics or putting the emitted messages in the emitted-messages-list
+func (p *producerMock) EmitWithHeaders(topic string, key string, value []byte, header map[string][]byte) *goka.Promise {
+	return p.emitter(topic, key, value)
+}
+
+// Emit emits messages to arbitrary topics.
+// The mock simply forwards the emit to the KafkaMock which takes care of queueing calls
+// to handled topics or putting the emitted messages in the emitted-messages-list
 func (p *producerMock) Emit(topic string, key string, value []byte) *goka.Promise {
 	return p.emitter(topic, key, value)
 }
@@ -37,6 +44,13 @@ func (p *producerMock) Close() error {
 type flushingProducer struct {
 	tester   *Tester
 	producer goka.Producer
+}
+
+// Emit using the underlying producer
+func (e *flushingProducer) EmitWithHeaders(topic string, key string, value []byte, header map[string][]byte) *goka.Promise {
+	prom := e.producer.EmitWithHeaders(topic, key, value, header)
+	e.tester.waitForClients()
+	return prom
 }
 
 // Emit using the underlying producer


### PR DESCRIPTION
Add additional emitter and producer functions which support setting Kafka headers.