### PR TITLE
Configure sarama.Logger to use "[Sarama] " prefix

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -79,7 +79,7 @@ func Default() Logger {
 func Debug(gokaDebug, saramaDebug bool) {
 	defaultLogger.debug = gokaDebug
 	if saramaDebug {
-		SetSaramaLogger(&std{debug: true})
+		SetSaramaLogger(&std{debug: true, prefix: "[Sarama] "})
 	}
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -79,7 +79,7 @@ func Default() Logger {
 func Debug(gokaDebug, saramaDebug bool) {
 	defaultLogger.debug = gokaDebug
 	if saramaDebug {
-		SetSaramaLogger(&std{debug: true, prefix: "[Sarama] "})
+		SetSaramaLogger((&std{debug: true}).Prefix("Sarama"))
 	}
 }
 


### PR DESCRIPTION
Sarama sets up its logger with `"[Sarama] "` prefix - check https://godoc.org/github.com/Shopify/sarama#pkg-variables. I suggest we do the same here - this way users are given a hint where the log message came from. Users that do not wish to have this prefix can still use `SetSaramaLogger` to override that behavior.