### PR TITLE
Add EmitSyncWithHeaders emitter method

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -88,13 +88,13 @@ func (e *Emitter) Emit(key string, msg interface{}) (*Promise, error) {
 	return e.EmitWithHeaders(key, msg, nil)
 }
 
-// EmitSync sends a message to passed topic and key.
-func (e *Emitter) EmitSync(key string, msg interface{}) error {
+// EmitWithHeadersSync sends a message with the given headers to passed topic and key.
+func (e *Emitter) EmitWithHeadersSync(key string, msg interface{}, headers map[string][]byte) error {
 	var (
 		err     error
 		promise *Promise
 	)
-	promise, err = e.Emit(key, msg)
+	promise, err = e.EmitWithHeaders(key, msg, headers)
 
 	if err != nil {
 		return err
@@ -107,6 +107,11 @@ func (e *Emitter) EmitSync(key string, msg interface{}) error {
 	})
 	<-done
 	return err
+}
+
+// EmitSync sends a message to passed topic and key.
+func (e *Emitter) EmitSync(key string, msg interface{}) error {
+	return e.EmitWithHeadersSync(key, msg, nil)
 }
 
 // Finish waits until the emitter is finished producing all pending messages.

--- a/emitter.go
+++ b/emitter.go
@@ -88,8 +88,8 @@ func (e *Emitter) Emit(key string, msg interface{}) (*Promise, error) {
 	return e.EmitWithHeaders(key, msg, nil)
 }
 
-// EmitWithHeadersSync sends a message with the given headers to passed topic and key.
-func (e *Emitter) EmitWithHeadersSync(key string, msg interface{}, headers map[string][]byte) error {
+// EmitSyncWithHeaders sends a message with the given headers to passed topic and key.
+func (e *Emitter) EmitSyncWithHeaders(key string, msg interface{}, headers map[string][]byte) error {
 	var (
 		err     error
 		promise *Promise
@@ -111,7 +111,7 @@ func (e *Emitter) EmitWithHeadersSync(key string, msg interface{}, headers map[s
 
 // EmitSync sends a message to passed topic and key.
 func (e *Emitter) EmitSync(key string, msg interface{}) error {
-	return e.EmitWithHeadersSync(key, msg, nil)
+	return e.EmitSyncWithHeaders(key, msg, nil)
 }
 
 // Finish waits until the emitter is finished producing all pending messages.


### PR DESCRIPTION
Being able to emit with headers is important to people who use tracing.