### PR TITLE
Tester: fix concurrent map access

### DIFF
--- a/tester/tester.go
+++ b/tester/tester.go
@@ -41,7 +41,7 @@ type Tester struct {
 	mClients sync.RWMutex
 	clients  map[string]*client
 
-	mCodecs sync.Mutex
+	mCodecs sync.RWMutex
 	codecs  map[string]goka.Codec
 
 	mQueues     sync.Mutex
@@ -216,6 +216,10 @@ func (tt *Tester) getOrCreateQueue(topic string) *queue {
 }
 
 func (tt *Tester) codecForTopic(topic string) goka.Codec {
+	// lock the access to codecs-map
+	tt.mCodecs.RLock()
+	defer tt.mCodecs.RUnlock()
+
 	codec, exists := tt.codecs[topic]
 	if !exists {
 		panic(fmt.Errorf("no codec for topic %s registered", topic))

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -41,7 +41,9 @@ type Tester struct {
 	mClients sync.RWMutex
 	clients  map[string]*client
 
-	codecs      map[string]goka.Codec
+	mCodecs sync.Mutex
+	codecs  map[string]goka.Codec
+
 	mQueues     sync.Mutex
 	topicQueues map[string]*queue
 
@@ -222,6 +224,10 @@ func (tt *Tester) codecForTopic(topic string) goka.Codec {
 }
 
 func (tt *Tester) registerCodec(topic string, codec goka.Codec) {
+	// lock the access to codecs-map
+	tt.mCodecs.Lock()
+	defer tt.mCodecs.Unlock()
+
 	// create a queue, we're going to need it anyway
 	tt.getOrCreateQueue(topic)
 


### PR DESCRIPTION
- protect `Tester. codecs` from concurrent map access