### PR TITLE
#277 unexport finish method of Promise

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -23,7 +23,7 @@ func newEmitter(err error, done func(err error)) emitter {
 		if done != nil {
 			p.Then(done)
 		}
-		return p.Finish(nil, err)
+		return p.finish(nil, err)
 	}
 }
 
@@ -34,7 +34,7 @@ func newEmitterW(wg *sync.WaitGroup, err error, done func(err error)) emitter {
 		if done != nil {
 			p.Then(done)
 		}
-		return p.Finish(nil, err)
+		return p.finish(nil, err)
 	}
 }
 
@@ -348,7 +348,7 @@ func TestContext_GetSetStateful(t *testing.T) {
 			test.AssertEqual(t, tp, graph.GroupTable().Topic())
 			test.AssertEqual(t, string(k), key)
 			test.AssertEqual(t, string(v), value)
-			return NewPromise().Finish(nil, nil)
+			return NewPromise().finish(nil, nil)
 		},
 		ctx: context.Background(),
 	}

--- a/emitter.go
+++ b/emitter.go
@@ -55,7 +55,7 @@ func NewEmitter(brokers []string, topic Stream, codec Codec, options ...EmitterO
 func (e *Emitter) EmitWithHeaders(key string, msg interface{}, headers map[string][]byte) (*Promise, error) {
 	select {
 	case <-e.done:
-		return NewPromise().Finish(nil, ErrEmitterAlreadyClosed), nil
+		return NewPromise().finish(nil, ErrEmitterAlreadyClosed), nil
 	default:
 	}
 

--- a/emitter_test.go
+++ b/emitter_test.go
@@ -68,7 +68,7 @@ func TestEmitter_Emit(t *testing.T) {
 			data   []byte = []byte(strconv.FormatInt(intVal, 10))
 		)
 
-		bm.producer.EXPECT().Emit(emitter.topic, key, data).Return(NewPromise().Finish(nil, nil))
+		bm.producer.EXPECT().Emit(emitter.topic, key, data).Return(NewPromise().finish(nil, nil))
 		promise, err := emitter.Emit(key, intVal)
 		test.AssertNil(t, err)
 		test.AssertNotNil(t, promise)
@@ -84,7 +84,7 @@ func TestEmitter_Emit(t *testing.T) {
 			retErr error  = errors.New("some-error")
 		)
 
-		bm.producer.EXPECT().Emit(emitter.topic, key, data).Return(NewPromise().Finish(nil, retErr))
+		bm.producer.EXPECT().Emit(emitter.topic, key, data).Return(NewPromise().finish(nil, retErr))
 		promise, err := emitter.Emit(key, intVal)
 		test.AssertNil(t, err)
 		test.AssertEqual(t, promise.err, retErr)
@@ -129,7 +129,7 @@ func TestEmitter_EmitSync(t *testing.T) {
 			data   []byte = []byte(strconv.FormatInt(intVal, 10))
 		)
 
-		bm.producer.EXPECT().Emit(emitter.topic, key, data).Return(NewPromise().Finish(nil, nil))
+		bm.producer.EXPECT().Emit(emitter.topic, key, data).Return(NewPromise().finish(nil, nil))
 		err := emitter.EmitSync(key, intVal)
 		test.AssertNil(t, err)
 	})
@@ -144,7 +144,7 @@ func TestEmitter_EmitSync(t *testing.T) {
 			retErr error  = errors.New("some-error")
 		)
 
-		bm.producer.EXPECT().Emit(emitter.topic, key, data).Return(NewPromise().Finish(nil, retErr))
+		bm.producer.EXPECT().Emit(emitter.topic, key, data).Return(NewPromise().finish(nil, retErr))
 		err := emitter.EmitSync(key, intVal)
 		test.AssertEqual(t, err, retErr)
 	})
@@ -188,7 +188,7 @@ func TestEmitter_Finish(t *testing.T) {
 			msgCount        = 200
 		)
 
-		bm.producer.EXPECT().Emit(emitter.topic, key, data).Return(NewPromise().Finish(nil, nil)).MaxTimes(msgCount)
+		bm.producer.EXPECT().Emit(emitter.topic, key, data).Return(NewPromise().finish(nil, nil)).MaxTimes(msgCount)
 		bm.producer.EXPECT().Close().Return(nil)
 
 		go func() {

--- a/processor_test.go
+++ b/processor_test.go
@@ -39,14 +39,14 @@ func createTestConsumerBuilder(t *testing.T) (SaramaConsumerBuilder, *MockAutoCo
 
 func expectCGEmit(bm *builderMock, table string, msgs []*sarama.ConsumerMessage) {
 	for _, msg := range msgs {
-		bm.producer.EXPECT().Emit(table, string(msg.Key), msg.Value).Return(NewPromise().Finish(nil, nil))
+		bm.producer.EXPECT().Emit(table, string(msg.Key), msg.Value).Return(NewPromise().finish(nil, nil))
 	}
 }
 
 func expectCGLoop(bm *builderMock, loop string, msgs []*sarama.ConsumerMessage) {
 	bm.tmgr.EXPECT().EnsureStreamExists(loop, 1).AnyTimes()
 	for _, msg := range msgs {
-		bm.producer.EXPECT().Emit(loop, string(msg.Key), gomock.Any()).Return(NewPromise().Finish(nil, nil))
+		bm.producer.EXPECT().Emit(loop, string(msg.Key), gomock.Any()).Return(NewPromise().finish(nil, nil))
 	}
 }
 

--- a/producer.go
+++ b/producer.go
@@ -109,7 +109,7 @@ func (p *producer) run() {
 			if !ok {
 				return
 			}
-			err.Msg.Metadata.(*Promise).Finish(nil, err.Err)
+			err.Msg.Metadata.(*Promise).finish(nil, err.Err)
 		}
 	}()
 
@@ -121,7 +121,7 @@ func (p *producer) run() {
 			if !ok {
 				return
 			}
-			msg.Metadata.(*Promise).Finish(msg, nil)
+			msg.Metadata.(*Promise).finish(msg, nil)
 		}
 	}()
 }

--- a/promise.go
+++ b/promise.go
@@ -16,9 +16,19 @@ type Promise struct {
 	callbacks []func(msg *sarama.ProducerMessage, err error)
 }
 
+// PromiseFinisher finishes a promise
+type PromiseFinisher func(msg *sarama.ProducerMessage, err error) *Promise
+
 // NewPromise creates a new Promise
 func NewPromise() *Promise {
 	return new(Promise)
+}
+
+// NewPromiseWithFinisher creates a new Promise and a separate finish method.
+// This is necessary if the promise is used outside of goka package.
+func NewPromiseWithFinisher() (*Promise, PromiseFinisher) {
+	p := new(Promise)
+	return p, p.finish
 }
 
 // execute all callbacks conveniently
@@ -58,7 +68,7 @@ func (p *Promise) ThenWithMessage(callback func(msg *sarama.ProducerMessage, err
 }
 
 // Finish finishes the promise by executing all callbacks and saving the message/error for late subscribers
-func (p *Promise) Finish(msg *sarama.ProducerMessage, err error) *Promise {
+func (p *Promise) finish(msg *sarama.ProducerMessage, err error) *Promise {
 	p.Lock()
 	defer p.Unlock()
 

--- a/promise_test.go
+++ b/promise_test.go
@@ -15,12 +15,12 @@ func TestPromise_thenBeforeFinish(t *testing.T) {
 		promiseErr = err
 	})
 
-	p.Finish(nil, errors.New("test"))
+	p.finish(nil, errors.New("test"))
 
 	test.AssertEqual(t, promiseErr.Error(), "test")
 
 	// repeating finish won't change result
-	p.Finish(nil, errors.New("test-whatever"))
+	p.finish(nil, errors.New("test-whatever"))
 
 	test.AssertEqual(t, promiseErr.Error(), "test")
 }
@@ -29,7 +29,7 @@ func TestPromise_thenAfterFinish(t *testing.T) {
 	p := new(Promise)
 
 	var promiseErr error
-	p.Finish(nil, errors.New("test"))
+	p.finish(nil, errors.New("test"))
 	p.Then(func(err error) {
 		promiseErr = err
 	})

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -131,9 +131,9 @@ func (tt *Tester) EmitterProducerBuilder() goka.ProducerBuilder {
 // This takes care of queueing calls
 // to handled topics or putting the emitted messages in the emitted-messages-list
 func (tt *Tester) handleEmit(topic string, key string, value []byte) *goka.Promise {
-	promise := goka.NewPromise()
+	_, finisher := goka.NewPromiseWithFinisher()
 	offset := tt.pushMessage(topic, key, value)
-	return promise.Finish(&sarama.ProducerMessage{Offset: offset}, nil)
+	return finisher(&sarama.ProducerMessage{Offset: offset}, nil)
 }
 
 func (tt *Tester) pushMessage(topic string, key string, data []byte) int64 {


### PR DESCRIPTION
unexports the Finish method from the promise, as it should always be called from the producer that created it. 
Resolves #277 