### PR TITLE
fix broken Signal.WaitForState lock, fix Emitter.Finish data races, fix data races in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp*
 *.*~
 .tags*
 vendor
+.vscode

--- a/context_test.go
+++ b/context_test.go
@@ -477,7 +477,7 @@ func TestContext_Join(t *testing.T) {
 		graph: DefineGroup("group", Persist(c), Loop(c, cb), Join(table, c)),
 		msg:   &sarama.ConsumerMessage{Key: []byte(key)},
 		pviews: map[string]*PartitionTable{
-			string(table): &PartitionTable{
+			string(table): {
 				log: logger.Default(),
 				st: &storageProxy{
 					Storage: st,
@@ -526,13 +526,13 @@ func TestContext_Lookup(t *testing.T) {
 		graph: DefineGroup("group", Persist(c), Loop(c, cb)),
 		msg:   &sarama.ConsumerMessage{Key: []byte(key)},
 		views: map[string]*View{
-			string(table): &View{
+			string(table): {
 				opts: &voptions{
 					tableCodec: c,
 					hasher:     DefaultHasher(),
 				},
 				partitions: []*PartitionTable{
-					&PartitionTable{
+					{
 						st: &storageProxy{
 							Storage: st,
 						},
@@ -579,7 +579,7 @@ func TestContext_Headers(t *testing.T) {
 
 	ctx = &cbContext{
 		msg: &sarama.ConsumerMessage{Key: []byte("key"), Headers: []*sarama.RecordHeader{
-			&sarama.RecordHeader{
+			{
 				Key:   []byte("key"),
 				Value: []byte("value"),
 			},

--- a/copartition_strategy_test.go
+++ b/copartition_strategy_test.go
@@ -27,7 +27,7 @@ func TestCopartitioningStrategy(t *testing.T) {
 			},
 			// topics are inconsistent with members
 			topics: map[string][]int32{
-				"T2": []int32{0, 1, 2},
+				"T2": {0, 1, 2},
 			},
 			hasError: true,
 		},
@@ -38,8 +38,8 @@ func TestCopartitioningStrategy(t *testing.T) {
 			},
 			// topics are inconsistent with members
 			topics: map[string][]int32{
-				"T1": []int32{0, 1, 2},
-				"T2": []int32{0, 1},
+				"T1": {0, 1, 2},
+				"T2": {0, 1},
 			},
 			hasError: true,
 		},
@@ -51,8 +51,8 @@ func TestCopartitioningStrategy(t *testing.T) {
 			},
 			// topics are inconsistent with members
 			topics: map[string][]int32{
-				"T1": []int32{0, 1, 2},
-				"T2": []int32{0, 1, 2},
+				"T1": {0, 1, 2},
+				"T2": {0, 1, 2},
 			},
 			hasError: true,
 		},
@@ -63,11 +63,11 @@ func TestCopartitioningStrategy(t *testing.T) {
 			},
 			// topics are inconsistent with members
 			topics: map[string][]int32{
-				"T1": []int32{0, 1, 2},
+				"T1": {0, 1, 2},
 			},
 			expected: sarama.BalanceStrategyPlan{
 				"M1": map[string][]int32{
-					"T1": []int32{0, 1, 2},
+					"T1": {0, 1, 2},
 				},
 			},
 		},
@@ -79,14 +79,14 @@ func TestCopartitioningStrategy(t *testing.T) {
 			},
 			// topics are inconsistent with members
 			topics: map[string][]int32{
-				"T1": []int32{0, 1, 2},
+				"T1": {0, 1, 2},
 			},
 			expected: sarama.BalanceStrategyPlan{
 				"M1": map[string][]int32{
-					"T1": []int32{0, 1},
+					"T1": {0, 1},
 				},
 				"M2": map[string][]int32{
-					"T1": []int32{2},
+					"T1": {2},
 				},
 			},
 		},
@@ -99,25 +99,25 @@ func TestCopartitioningStrategy(t *testing.T) {
 			},
 			// topics are inconsistent with members
 			topics: map[string][]int32{
-				"T1": []int32{0, 1, 2, 3, 4, 5},
-				"T2": []int32{0, 1, 2, 3, 4, 5},
-				"T3": []int32{0, 1, 2, 3, 4, 5},
+				"T1": {0, 1, 2, 3, 4, 5},
+				"T2": {0, 1, 2, 3, 4, 5},
+				"T3": {0, 1, 2, 3, 4, 5},
 			},
 			expected: sarama.BalanceStrategyPlan{
 				"M1": map[string][]int32{
-					"T1": []int32{0, 1},
-					"T2": []int32{0, 1},
-					"T3": []int32{0, 1},
+					"T1": {0, 1},
+					"T2": {0, 1},
+					"T3": {0, 1},
 				},
 				"M2": map[string][]int32{
-					"T1": []int32{2, 3},
-					"T2": []int32{2, 3},
-					"T3": []int32{2, 3},
+					"T1": {2, 3},
+					"T2": {2, 3},
+					"T3": {2, 3},
 				},
 				"M3": map[string][]int32{
-					"T1": []int32{4, 5},
-					"T2": []int32{4, 5},
-					"T3": []int32{4, 5},
+					"T1": {4, 5},
+					"T2": {4, 5},
+					"T3": {4, 5},
 				},
 			},
 		},

--- a/emitter.go
+++ b/emitter.go
@@ -19,6 +19,7 @@ type Emitter struct {
 	topic string
 
 	wg   sync.WaitGroup
+	mu   sync.Mutex
 	done chan struct{}
 }
 
@@ -51,14 +52,10 @@ func NewEmitter(brokers []string, topic Stream, codec Codec, options ...EmitterO
 	}, nil
 }
 
+func (e *Emitter) emitDone(err error) { e.wg.Done() }
+
 // EmitWithHeaders sends a message with the given headers for the passed key using the emitter's codec.
 func (e *Emitter) EmitWithHeaders(key string, msg interface{}, headers map[string][]byte) (*Promise, error) {
-	select {
-	case <-e.done:
-		return NewPromise().finish(nil, ErrEmitterAlreadyClosed), nil
-	default:
-	}
-
 	var (
 		err  error
 		data []byte
@@ -70,17 +67,22 @@ func (e *Emitter) EmitWithHeaders(key string, msg interface{}, headers map[strin
 			return nil, fmt.Errorf("Error encoding value for key %s in topic %s: %v", key, e.topic, err)
 		}
 	}
-	e.wg.Add(1)
-	if headers == nil {
-		return e.producer.Emit(e.topic, key, data).Then(func(err error) {
-			e.wg.Done()
-		}), nil
-	} else {
-		return e.producer.EmitWithHeaders(e.topic, key, data, headers).Then(func(err error) {
-			e.wg.Done()
-		}), nil
+
+	// protect e.done channel and e.wg WaitGroup together to reject all new emits after calling e.Finish
+	e.mu.Lock()
+	select {
+	case <-e.done:
+		e.mu.Unlock()
+		return NewPromise().finish(nil, ErrEmitterAlreadyClosed), nil
+	default:
+		e.wg.Add(1)
+		e.mu.Unlock()
 	}
 
+	if headers == nil {
+		return e.producer.Emit(e.topic, key, data).Then(e.emitDone), nil
+	}
+	return e.producer.EmitWithHeaders(e.topic, key, data, headers).Then(e.emitDone), nil
 }
 
 // Emit sends a message for passed key using the emitter's codec.
@@ -116,7 +118,9 @@ func (e *Emitter) EmitSync(key string, msg interface{}) error {
 
 // Finish waits until the emitter is finished producing all pending messages.
 func (e *Emitter) Finish() error {
+	e.mu.Lock()
 	close(e.done)
+	e.mu.Unlock()
 	e.wg.Wait()
 	return e.producer.Close()
 }

--- a/partition_table_test.go
+++ b/partition_table_test.go
@@ -373,9 +373,9 @@ func TestPT_load(t *testing.T) {
 			consumer               = defaultSaramaAutoConsumerMock(t)
 			topic                  = "some-topic"
 			partition        int32
-			count                           = new(int64)
+			count            int64
 			updateCB         UpdateCallback = func(s storage.Storage, partition int32, key string, value []byte) error {
-				atomic.AddInt64(count, 1)
+				atomic.AddInt64(&count, 1)
 				return nil
 			}
 		)
@@ -408,7 +408,7 @@ func TestPT_load(t *testing.T) {
 					return
 				default:
 				}
-				if atomic.LoadInt64(count) == 10 {
+				if atomic.LoadInt64(&count) == 10 {
 					cancel()
 					return
 				}
@@ -419,7 +419,7 @@ func TestPT_load(t *testing.T) {
 		test.AssertNil(t, err)
 		err = pt.load(ctx, stopAfterCatchup)
 		test.AssertNil(t, err)
-		test.AssertTrue(t, atomic.LoadInt64(count) == 10)
+		test.AssertTrue(t, atomic.LoadInt64(&count) == 10)
 	})
 }
 
@@ -522,10 +522,10 @@ func TestPT_loadMessages(t *testing.T) {
 			stopAfterCatchup       = false
 			topic                  = "some-topic"
 			partition        int32
-			consumer                        = defaultSaramaAutoConsumerMock(t)
-			count                           = new(int64)
+			consumer         = defaultSaramaAutoConsumerMock(t)
+			count            int64
 			updateCB         UpdateCallback = func(s storage.Storage, partition int32, key string, value []byte) error {
-				atomic.AddInt64(count, 1)
+				atomic.AddInt64(&count, 1)
 				return nil
 			}
 		)
@@ -554,7 +554,7 @@ func TestPT_loadMessages(t *testing.T) {
 					return
 				default:
 				}
-				if atomic.LoadInt64(count) == 100 {
+				if atomic.LoadInt64(&count) == 100 {
 					break
 				}
 			}
@@ -562,7 +562,7 @@ func TestPT_loadMessages(t *testing.T) {
 		}(ctx)
 		err = pt.loadMessages(ctx, partConsumer, partitionHwm, stopAfterCatchup)
 		test.AssertNil(t, err)
-		test.AssertTrue(t, atomic.LoadInt64(count) == 100)
+		test.AssertTrue(t, atomic.LoadInt64(&count) == 100)
 	})
 	t.Run("close_msg_chan", func(t *testing.T) {
 		var (
@@ -866,9 +866,9 @@ func TestPT_SetupAndCatchupToHwm(t *testing.T) {
 			consumer        = defaultSaramaAutoConsumerMock(t)
 			topic           = "some-topic"
 			partition int32
-			count                    = new(int64)
+			count     int64
 			updateCB  UpdateCallback = func(s storage.Storage, partition int32, key string, value []byte) error {
-				atomic.AddInt64(count, 1)
+				atomic.AddInt64(&count, 1)
 				return nil
 			}
 		)
@@ -901,7 +901,7 @@ func TestPT_SetupAndCatchupToHwm(t *testing.T) {
 
 		err := pt.SetupAndRecover(ctx, false)
 		test.AssertNil(t, err)
-		test.AssertTrue(t, atomic.LoadInt64(count) == msgsToRecover)
+		test.AssertTrue(t, atomic.LoadInt64(&count) == msgsToRecover)
 	})
 	t.Run("fail", func(t *testing.T) {
 		var (
@@ -937,9 +937,9 @@ func TestPT_SetupAndCatchupForever(t *testing.T) {
 			consumer        = defaultSaramaAutoConsumerMock(t)
 			topic           = "some-topic"
 			partition int32
-			count                    = new(int64)
+			count     int64
 			updateCB  UpdateCallback = func(s storage.Storage, partition int32, key string, value []byte) error {
-				atomic.AddInt64(count, 1)
+				atomic.AddInt64(&count, 1)
 				return nil
 			}
 		)
@@ -969,7 +969,7 @@ func TestPT_SetupAndCatchupForever(t *testing.T) {
 					return
 				default:
 				}
-				if atomic.LoadInt64(count) == 10 {
+				if atomic.LoadInt64(&count) == 10 {
 					time.Sleep(time.Millisecond * 10)
 					cancel()
 					return

--- a/partition_table_test.go
+++ b/partition_table_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -372,9 +373,9 @@ func TestPT_load(t *testing.T) {
 			consumer               = defaultSaramaAutoConsumerMock(t)
 			topic                  = "some-topic"
 			partition        int32
-			count            int32
+			count                           = new(int64)
 			updateCB         UpdateCallback = func(s storage.Storage, partition int32, key string, value []byte) error {
-				count++
+				atomic.AddInt64(count, 1)
 				return nil
 			}
 		)
@@ -407,7 +408,7 @@ func TestPT_load(t *testing.T) {
 					return
 				default:
 				}
-				if count == 10 {
+				if atomic.LoadInt64(count) == 10 {
 					cancel()
 					return
 				}
@@ -418,7 +419,7 @@ func TestPT_load(t *testing.T) {
 		test.AssertNil(t, err)
 		err = pt.load(ctx, stopAfterCatchup)
 		test.AssertNil(t, err)
-		test.AssertTrue(t, count == 10)
+		test.AssertTrue(t, atomic.LoadInt64(count) == 10)
 	})
 }
 
@@ -521,10 +522,10 @@ func TestPT_loadMessages(t *testing.T) {
 			stopAfterCatchup       = false
 			topic                  = "some-topic"
 			partition        int32
-			consumer         = defaultSaramaAutoConsumerMock(t)
-			count            int32
+			consumer                        = defaultSaramaAutoConsumerMock(t)
+			count                           = new(int64)
 			updateCB         UpdateCallback = func(s storage.Storage, partition int32, key string, value []byte) error {
-				count++
+				atomic.AddInt64(count, 1)
 				return nil
 			}
 		)
@@ -553,7 +554,7 @@ func TestPT_loadMessages(t *testing.T) {
 					return
 				default:
 				}
-				if count == 100 {
+				if atomic.LoadInt64(count) == 100 {
 					break
 				}
 			}
@@ -561,7 +562,7 @@ func TestPT_loadMessages(t *testing.T) {
 		}(ctx)
 		err = pt.loadMessages(ctx, partConsumer, partitionHwm, stopAfterCatchup)
 		test.AssertNil(t, err)
-		test.AssertTrue(t, count == 100)
+		test.AssertTrue(t, atomic.LoadInt64(count) == 100)
 	})
 	t.Run("close_msg_chan", func(t *testing.T) {
 		var (
@@ -865,9 +866,9 @@ func TestPT_SetupAndCatchupToHwm(t *testing.T) {
 			consumer        = defaultSaramaAutoConsumerMock(t)
 			topic           = "some-topic"
 			partition int32
-			count     int64
+			count                    = new(int64)
 			updateCB  UpdateCallback = func(s storage.Storage, partition int32, key string, value []byte) error {
-				count++
+				atomic.AddInt64(count, 1)
 				return nil
 			}
 		)
@@ -900,7 +901,7 @@ func TestPT_SetupAndCatchupToHwm(t *testing.T) {
 
 		err := pt.SetupAndRecover(ctx, false)
 		test.AssertNil(t, err)
-		test.AssertTrue(t, count == msgsToRecover)
+		test.AssertTrue(t, atomic.LoadInt64(count) == msgsToRecover)
 	})
 	t.Run("fail", func(t *testing.T) {
 		var (
@@ -936,9 +937,9 @@ func TestPT_SetupAndCatchupForever(t *testing.T) {
 			consumer        = defaultSaramaAutoConsumerMock(t)
 			topic           = "some-topic"
 			partition int32
-			count     int64
+			count                    = new(int64)
 			updateCB  UpdateCallback = func(s storage.Storage, partition int32, key string, value []byte) error {
-				count++
+				atomic.AddInt64(count, 1)
 				return nil
 			}
 		)
@@ -968,7 +969,7 @@ func TestPT_SetupAndCatchupForever(t *testing.T) {
 					return
 				default:
 				}
-				if count == 10 {
+				if atomic.LoadInt64(count) == 10 {
 					time.Sleep(time.Millisecond * 10)
 					cancel()
 					return

--- a/processor_test.go
+++ b/processor_test.go
@@ -92,11 +92,13 @@ func TestProcessor_Run(t *testing.T) {
 		var (
 			topic  = "test-table"
 			toEmit = []*sarama.ConsumerMessage{
-				&sarama.ConsumerMessage{Topic: "input",
+				{
+					Topic: "input",
 					Value: []byte(strconv.FormatInt(3, 10)),
 					Key:   []byte("test-key-1"),
 				},
-				&sarama.ConsumerMessage{Topic: "input",
+				{
+					Topic: "input",
 					Value: []byte(strconv.FormatInt(3, 10)),
 					Key:   []byte("test-key-2"),
 				},
@@ -166,7 +168,8 @@ func TestProcessor_Run(t *testing.T) {
 			topic  = "test-table"
 			loop   = "test-loop"
 			toEmit = []*sarama.ConsumerMessage{
-				&sarama.ConsumerMessage{Topic: "input",
+				{
+					Topic: "input",
 					Value: []byte(strconv.FormatInt(23, 10)),
 					Key:   []byte("test-key"),
 				},

--- a/signal.go
+++ b/signal.go
@@ -88,8 +88,6 @@ func (s *Signal) State() State {
 // WaitForStateMin returns a channel that will be closed, when the signal enters passed
 // state or higher (states are ints, so we're just comparing ints here)
 func (s *Signal) WaitForStateMin(state State) chan struct{} {
-	s.m.Lock()
-	defer s.m.Unlock()
 
 	w := &waiter{
 		done:     make(chan struct{}),
@@ -103,8 +101,6 @@ func (s *Signal) WaitForStateMin(state State) chan struct{} {
 // WaitForState returns a channel that closes when the signal reaches passed
 // state.
 func (s *Signal) WaitForState(state State) chan struct{} {
-	s.m.Lock()
-	s.m.Unlock()
 
 	w := &waiter{
 		done:  make(chan struct{}),
@@ -115,9 +111,10 @@ func (s *Signal) WaitForState(state State) chan struct{} {
 }
 
 func (s *Signal) waitForWaiter(state State, w *waiter) chan struct{} {
-
 	// if the signal is currently in that state (or in a higher state if minState is set)
 	// then close the waiter immediately
+	s.m.Lock()
+	defer s.m.Unlock()
 	if curState := s.state; state == curState || (w.minState && curState >= state) {
 		close(w.done)
 	} else {

--- a/topic_manager_test.go
+++ b/topic_manager_test.go
@@ -336,7 +336,7 @@ func TestTM_createTopic(t *testing.T) {
 		)
 		bm.broker.EXPECT().CreateTopics(gomock.Any()).Return(&sarama.CreateTopicsResponse{
 			TopicErrors: map[string]*sarama.TopicError{
-				"a": &sarama.TopicError{
+				"a": {
 					Err:    sarama.KError(0),
 					ErrMsg: &errMsg,
 				},

--- a/view_test.go
+++ b/view_test.go
@@ -525,9 +525,9 @@ func TestView_Run(t *testing.T) {
 			// local     int64          = oldest
 			consumer  = defaultSaramaAutoConsumerMock(t)
 			partition int32
-			count                    = new(int64)
+			count     int64
 			updateCB  UpdateCallback = func(s storage.Storage, partition int32, key string, value []byte) error {
-				atomic.AddInt64(count, 1)
+				atomic.AddInt64(&count, 1)
 				return nil
 			}
 		)
@@ -565,7 +565,7 @@ func TestView_Run(t *testing.T) {
 					return
 				default:
 				}
-				if atomic.LoadInt64(count) == 10 {
+				if atomic.LoadInt64(&count) == 10 {
 					time.Sleep(time.Millisecond * 10)
 					cancel()
 					return


### PR DESCRIPTION
- fixed all data races in the tests using sync counters
- Mocks: added mutexes where missing
- Signal: fixed broken WaitForState lock
- Emitter: added Emit mutex to avoid racy emits during e.Finish