### PR TITLE
fix topic manager stream retention not in milliseconds

### DIFF
--- a/topic_manager.go
+++ b/topic_manager.go
@@ -177,7 +177,7 @@ func (m *topicManager) EnsureStreamExists(topic string, npar int) error {
 		npar,
 		m.topicManagerConfig.Stream.Replication,
 		map[string]string{
-			"retention.ms": fmt.Sprintf("%d", m.topicManagerConfig.Stream.Retention),
+			"retention.ms": fmt.Sprintf("%d", m.topicManagerConfig.Stream.Retention.Milliseconds()),
 		})
 }
 


### PR DESCRIPTION
Noticed that topics created with TopicManager.EnsureStreamExists had much longer retention than expected, and setting it to -1 to avoid deletion doesn't work either.
%d on a duration seems to print out number of microseconds, and not milliseconds:
```
t := 1 * time.Hour
fmt.Printf("%d", t)
```
gives:
`3600000000000`