### PR TITLE
Missing file from #298

### DIFF
--- a/context.go
+++ b/context.go
@@ -170,12 +170,6 @@ type cbContext struct {
 	wg     *sync.WaitGroup
 }
 
-func WithCtxEmitHeaders(headers map[string][]byte) ContextOption{
-	return func(opts *ctxOptions){
-		opts.emitHeaders = headers
-	}
-}
-
 // Emit sends a message asynchronously to a topic.
 func (ctx *cbContext) Emit(topic Stream, key string, value interface{}, options ...ContextOption) {
 	opts := new(ctxOptions)


### PR DESCRIPTION
This a little embarrassing, but in my previous pull request, I did not add context.go to my final commit when I moved WithCtxEmitHeaders from context.go to options.go, resulting in a duplicate declaration. I apologize for the inconvenience.