### PR TITLE
Bugfix draining consumer message.

### DIFF
--- a/partition_table.go
+++ b/partition_table.go
@@ -105,7 +105,7 @@ func newPartitionTable(topic string,
 	return pt
 }
 
-// SetupAndRecover sets up the partition storage and recovers to HWM
+// SetupAndRecover  sets up the partition storage and recovers to HWM
 func (p *PartitionTable) SetupAndRecover(ctx context.Context, restartOnError bool) error {
 
 	err := p.setup(ctx)
@@ -464,7 +464,6 @@ func (p *PartitionTable) drainConsumer(cons sarama.PartitionConsumer, errs *mult
 				}
 				errs.Collect(err)
 			}
-			return nil
 		}
 	})
 
@@ -480,7 +479,6 @@ func (p *PartitionTable) drainConsumer(cons sarama.PartitionConsumer, errs *mult
 					return nil
 				}
 			}
-			return nil
 		}
 	})
 


### PR DESCRIPTION
There was a (very rarely occuring) error on rebalance in combination with option RecoverAhead, failing to create two consumers for the same topic+partition, failing the whole processor. This was caused by an early return, which allowed the rebalance before the previous consumer was fully closed, so creating a second consumer failed.

This PR fixes it and adds a test for that scenario.