### PR TITLE
Expose headers via the root package

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/lovoo/goka/headers"
 	"strings"
 	"sync"
 	"testing"
@@ -19,7 +18,7 @@ import (
 )
 
 func newEmitter(err error, done func(err error)) emitter {
-	return func(topic string, key string, value []byte, hdr headers.Headers) *Promise {
+	return func(topic string, key string, value []byte, hdr Headers) *Promise {
 		p := NewPromise()
 		if done != nil {
 			p.Then(done)
@@ -29,7 +28,7 @@ func newEmitter(err error, done func(err error)) emitter {
 }
 
 func newEmitterW(wg *sync.WaitGroup, err error, done func(err error)) emitter {
-	return func(topic string, key string, value []byte, hdr headers.Headers) *Promise {
+	return func(topic string, key string, value []byte, hdr Headers) *Promise {
 		wg.Add(1)
 		p := NewPromise()
 		if done != nil {
@@ -60,7 +59,7 @@ func TestContext_Emit(t *testing.T) {
 	})
 
 	ctx.start()
-	ctx.emit("emit-topic", "key", []byte("value"), headers.Headers{})
+	ctx.emit("emit-topic", "key", []byte("value"), Headers{})
 	ctx.finish(nil)
 
 	// we can now for all callbacks -- it should also guarantee a memory fence
@@ -165,7 +164,7 @@ func TestContext_EmitError(t *testing.T) {
 	})
 
 	ctx.start()
-	ctx.emit("emit-topic", "key", []byte("value"), headers.Headers{})
+	ctx.emit("emit-topic", "key", []byte("value"), Headers{})
 	ctx.finish(nil)
 
 	// we can now for all callbacks -- it should also guarantee a memory fence
@@ -251,7 +250,7 @@ func TestContext_Delete(t *testing.T) {
 	ctx.emitter = newEmitter(nil, nil)
 
 	ctx.start()
-	err := ctx.deleteKey(key, headers.Headers{})
+	err := ctx.deleteKey(key, Headers{})
 	test.AssertNil(t, err)
 	ctx.finish(nil)
 
@@ -281,7 +280,7 @@ func TestContext_DeleteStateless(t *testing.T) {
 	}
 	ctx.emitter = newEmitter(nil, nil)
 
-	err := ctx.deleteKey(key, headers.Headers{})
+	err := ctx.deleteKey(key, Headers{})
 	test.AssertTrue(t, strings.Contains(err.Error(), "Cannot access state in stateless processor"))
 }
 
@@ -314,7 +313,7 @@ func TestContext_DeleteStorageError(t *testing.T) {
 
 	ctx.emitter = newEmitter(nil, nil)
 
-	err := ctx.deleteKey(key, headers.Headers{})
+	err := ctx.deleteKey(key, Headers{})
 	test.AssertTrue(t, strings.Contains(err.Error(), "error deleting key (key) from storage: storage error"))
 }
 
@@ -352,7 +351,7 @@ func TestContext_Set(t *testing.T) {
 	ctx.emitter = newEmitter(nil, nil)
 
 	ctx.start()
-	err := ctx.setValueForKey(key, value, headers.Headers{})
+	err := ctx.setValueForKey(key, value, Headers{})
 	test.AssertNil(t, err)
 	ctx.finish(nil)
 
@@ -374,7 +373,7 @@ func TestContext_GetSetStateful(t *testing.T) {
 		group  Group = "some-group"
 		key          = "key"
 		value        = "value"
-		hdr          = headers.Headers{"key": []byte("headerValue")}
+		hdr          = Headers{"key": []byte("headerValue")}
 		offset       = int64(123)
 		wg           = new(sync.WaitGroup)
 		st           = NewMockStorage(ctrl)
@@ -399,7 +398,7 @@ func TestContext_GetSetStateful(t *testing.T) {
 		graph:            graph,
 		trackOutputStats: func(ctx context.Context, topic string, size int) {},
 		msg:              &sarama.ConsumerMessage{Key: []byte(key), Offset: offset},
-		emitter: func(tp string, k string, v []byte, h headers.Headers) *Promise {
+		emitter: func(tp string, k string, v []byte, h Headers) *Promise {
 			wg.Add(1)
 			test.AssertEqual(t, tp, graph.GroupTable().Topic())
 			test.AssertEqual(t, string(k), key)
@@ -452,17 +451,17 @@ func TestContext_SetErrors(t *testing.T) {
 		asyncFailer:      failer,
 	}
 
-	err := ctx.setValueForKey(key, nil, headers.Headers{})
+	err := ctx.setValueForKey(key, nil, Headers{})
 	test.AssertNotNil(t, err)
 	test.AssertTrue(t, strings.Contains(err.Error(), "cannot set nil"))
 
-	err = ctx.setValueForKey(key, 123, headers.Headers{}) // cannot encode 123 as string
+	err = ctx.setValueForKey(key, 123, Headers{}) // cannot encode 123 as string
 	test.AssertNotNil(t, err)
 	test.AssertTrue(t, strings.Contains(err.Error(), "error encoding"))
 
 	st.EXPECT().Set(key, []byte(value)).Return(errors.New("some-error"))
 
-	err = ctx.setValueForKey(key, value, headers.Headers{})
+	err = ctx.setValueForKey(key, value, Headers{})
 	test.AssertNotNil(t, err)
 	test.AssertTrue(t, strings.Contains(err.Error(), "some-error"))
 
@@ -497,7 +496,7 @@ func TestContext_Loopback(t *testing.T) {
 	var (
 		key   = "key"
 		value = "value"
-		hdr   = headers.Headers{"key": []byte("headerValue")}
+		hdr   = Headers{"key": []byte("headerValue")}
 		cnt   = 0
 	)
 
@@ -506,7 +505,7 @@ func TestContext_Loopback(t *testing.T) {
 		graph:            graph,
 		msg:              &sarama.ConsumerMessage{},
 		trackOutputStats: func(ctx context.Context, topic string, size int) {},
-		emitter: func(tp string, k string, v []byte, h headers.Headers) *Promise {
+		emitter: func(tp string, k string, v []byte, h Headers) *Promise {
 			cnt++
 			test.AssertEqual(t, tp, graph.LoopStream().Topic())
 			test.AssertEqual(t, string(k), key)

--- a/emitter.go
+++ b/emitter.go
@@ -3,7 +3,6 @@ package goka
 import (
 	"errors"
 	"fmt"
-	"github.com/lovoo/goka/headers"
 	"sync"
 )
 
@@ -18,7 +17,7 @@ type Emitter struct {
 	producer Producer
 
 	topic          string
-	defaultHeaders headers.Headers
+	defaultHeaders Headers
 
 	wg   sync.WaitGroup
 	mu   sync.RWMutex
@@ -58,7 +57,7 @@ func NewEmitter(brokers []string, topic Stream, codec Codec, options ...EmitterO
 func (e *Emitter) emitDone(err error) { e.wg.Done() }
 
 // EmitWithHeaders sends a message with the given headers for the passed key using the emitter's codec.
-func (e *Emitter) EmitWithHeaders(key string, msg interface{}, hdr headers.Headers) (*Promise, error) {
+func (e *Emitter) EmitWithHeaders(key string, msg interface{}, hdr Headers) (*Promise, error) {
 	var (
 		err  error
 		data []byte
@@ -96,7 +95,7 @@ func (e *Emitter) Emit(key string, msg interface{}) (*Promise, error) {
 }
 
 // EmitSyncWithHeaders sends a message with the given headers to passed topic and key.
-func (e *Emitter) EmitSyncWithHeaders(key string, msg interface{}, hdr headers.Headers) error {
+func (e *Emitter) EmitSyncWithHeaders(key string, msg interface{}, hdr Headers) error {
 	var (
 		err     error
 		promise *Promise

--- a/emitter_test.go
+++ b/emitter_test.go
@@ -2,7 +2,6 @@ package goka
 
 import (
 	"errors"
-	"github.com/lovoo/goka/headers"
 	"hash"
 	"strconv"
 	"testing"
@@ -119,7 +118,7 @@ func TestEmitter_Emit(t *testing.T) {
 	})
 	t.Run("default_headers", func(t *testing.T) {
 		emitter, bm, ctrl := createEmitter(t)
-		emitter.defaultHeaders = headers.Headers{"header-key": []byte("header-val")}
+		emitter.defaultHeaders = Headers{"header-key": []byte("header-val")}
 		defer ctrl.Finish()
 
 		var (

--- a/headers.go
+++ b/headers.go
@@ -1,0 +1,9 @@
+package goka
+
+import (
+	"github.com/lovoo/goka/headers"
+)
+
+// Headers is an alias for headers.Headers for a more elegant import experience.
+// I.e. `goka.Headers` instead of `headers.Headers`.
+type Headers = headers.Headers

--- a/integrationtest/processor_test.go
+++ b/integrationtest/processor_test.go
@@ -3,7 +3,6 @@ package integrationtest
 import (
 	"context"
 	"fmt"
-	"github.com/lovoo/goka/headers"
 	"log"
 	"strings"
 	"testing"
@@ -98,8 +97,8 @@ func TestErrorCallback(t *testing.T) {
 func TestHeaders(t *testing.T) {
 	var (
 		gkt              = tester.New(t)
-		processorHeaders headers.Headers
-		outputHeaders    headers.Headers
+		processorHeaders goka.Headers
+		outputHeaders    goka.Headers
 	)
 
 	// create a new processor, registering the tester
@@ -108,12 +107,12 @@ func TestHeaders(t *testing.T) {
 			processorHeaders = ctx.Headers()
 			ctx.Emit("output", ctx.Key(), fmt.Sprintf("forwarded: %v", msg),
 				goka.WithCtxEmitHeaders(
-					headers.Headers{
+					goka.Headers{
 						"Header1": []byte("to output"),
 						"Header2": []byte("to output2"),
 					}),
 				goka.WithCtxEmitHeaders(
-					headers.Headers{
+					goka.Headers{
 						"Header2": []byte("to output3"),
 						"Header3": []byte("to output4"),
 					}),
@@ -142,12 +141,12 @@ func TestHeaders(t *testing.T) {
 
 	// send some message
 	gkt.Consume("input", "key", "some-message", tester.WithHeaders(
-		headers.Headers{
+		goka.Headers{
 			"Header1": []byte("value 1"),
 			"Header2": []byte("value 2"),
 		}),
 		tester.WithHeaders(
-			headers.Headers{
+			goka.Headers{
 				"Header2": []byte("value 3"),
 				"Header3": []byte("value 4"),
 			}),

--- a/mocks.go
+++ b/mocks.go
@@ -7,7 +7,6 @@ package goka
 import (
 	sarama "github.com/Shopify/sarama"
 	gomock "github.com/golang/mock/gomock"
-	"github.com/lovoo/goka/headers"
 	reflect "reflect"
 )
 
@@ -172,7 +171,7 @@ func (mr *MockProducerMockRecorder) Emit(arg0, arg1, arg2 interface{}) *gomock.C
 }
 
 // EmitWithHeaders mocks base method
-func (m *MockProducer) EmitWithHeaders(arg0, arg1 string, arg2 []byte, arg3 headers.Headers) *Promise {
+func (m *MockProducer) EmitWithHeaders(arg0, arg1 string, arg2 []byte, arg3 Headers) *Promise {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EmitWithHeaders", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*Promise)

--- a/options.go
+++ b/options.go
@@ -2,7 +2,6 @@ package goka
 
 import (
 	"fmt"
-	"github.com/lovoo/goka/headers"
 	"hash"
 	"hash/fnv"
 	"log"
@@ -88,7 +87,7 @@ type poptions struct {
 	backoffResetTime       time.Duration
 	hotStandby             bool
 	recoverAhead           bool
-	producerDefaultHeaders headers.Headers
+	producerDefaultHeaders Headers
 
 	builders struct {
 		storage        storage.Builder
@@ -219,7 +218,7 @@ func WithBackoffResetTimeout(duration time.Duration) ProcessorOption {
 
 // WithProducerDefaultHeaders configures the producer with default headers
 // which are included with every emit.
-func WithProducerDefaultHeaders(hdr headers.Headers) ProcessorOption {
+func WithProducerDefaultHeaders(hdr Headers) ProcessorOption {
 	return func(p *poptions, graph *GroupGraph) {
 		p.producerDefaultHeaders = hdr
 	}
@@ -484,7 +483,7 @@ type eoptions struct {
 	clientID string
 
 	hasher         func() hash.Hash32
-	defaultHeaders headers.Headers
+	defaultHeaders Headers
 
 	builders struct {
 		topicmgr TopicManagerBuilder
@@ -540,7 +539,7 @@ func WithEmitterTester(t Tester) EmitterOption {
 
 // WithEmitterDefaultHeaders configures the emitter with default headers
 // which are included with every emit.
-func WithEmitterDefaultHeaders(hdr headers.Headers) EmitterOption {
+func WithEmitterDefaultHeaders(hdr Headers) EmitterOption {
 	return func(o *eoptions, _ Stream, _ Codec) {
 		o.defaultHeaders = hdr
 	}
@@ -565,7 +564,7 @@ func (opt *eoptions) applyOptions(topic Stream, codec Codec, opts ...EmitterOpti
 }
 
 type ctxOptions struct {
-	emitHeaders headers.Headers
+	emitHeaders Headers
 }
 
 // ContextOption defines a configuration option to be used when performing
@@ -573,10 +572,10 @@ type ctxOptions struct {
 type ContextOption func(*ctxOptions)
 
 // WithCtxEmitHeaders sets kafka headers to use when emitting to kafka
-func WithCtxEmitHeaders(hdr headers.Headers) ContextOption {
+func WithCtxEmitHeaders(hdr Headers) ContextOption {
 	return func(opts *ctxOptions) {
 		if opts.emitHeaders == nil {
-			opts.emitHeaders = make(headers.Headers, len(hdr))
+			opts.emitHeaders = make(Headers, len(hdr))
 		}
 		for k, v := range hdr {
 			opts.emitHeaders[k] = v

--- a/producer.go
+++ b/producer.go
@@ -2,7 +2,6 @@ package goka
 
 import (
 	"fmt"
-	"github.com/lovoo/goka/headers"
 	"sync"
 	"time"
 
@@ -13,7 +12,7 @@ import (
 type Producer interface {
 	// Emit sends a message to topic.
 	Emit(topic string, key string, value []byte) *Promise
-	EmitWithHeaders(topic string, key string, value []byte, hdr headers.Headers) *Promise
+	EmitWithHeaders(topic string, key string, value []byte, hdr Headers) *Promise
 	Close() error
 }
 
@@ -76,7 +75,7 @@ func (p *producer) Emit(topic string, key string, value []byte) *Promise {
 
 // EmitWithHeaders emits a key-value pair with headers to topic and returns a Promise that
 // can be checked for errors asynchronously
-func (p *producer) EmitWithHeaders(topic string, key string, value []byte, hdr headers.Headers) *Promise {
+func (p *producer) EmitWithHeaders(topic string, key string, value []byte, hdr Headers) *Promise {
 	promise := NewPromise()
 
 	p.producer.Input() <- &sarama.ProducerMessage{

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -3,9 +3,9 @@ package storage
 import (
 	"bytes"
 	"fmt"
-	"github.com/lovoo/goka/headers"
 	"strings"
 
+	"github.com/lovoo/goka/headers"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 

--- a/systemtest/processor_test.go
+++ b/systemtest/processor_test.go
@@ -289,6 +289,10 @@ func TestRecoverAhead(t *testing.T) {
 // TestRebalance runs some processors to test rebalance. It's merely a
 // runs-without-errors test, not a real functional test.
 func TestRebalance(t *testing.T) {
+	if !*systemtest {
+		t.Skipf("Ignoring systemtest. pass '-args -systemtest' to `go test` to include them")
+	}
+
 	var (
 		group       goka.Group = "goka-systemtest-rebalance"
 		inputStream string     = string(group) + "-input"

--- a/tester/producer.go
+++ b/tester/producer.go
@@ -2,7 +2,6 @@ package tester
 
 import (
 	"github.com/lovoo/goka"
-	"github.com/lovoo/goka/headers"
 )
 
 // emitHandler abstracts a function that allows to overwrite kafkamock's Emit function to
@@ -22,7 +21,7 @@ func newProducerMock(emitter emitHandler) *producerMock {
 // Emit emits messages to arbitrary topics.
 // The mock simply forwards the emit to the KafkaMock which takes care of queueing calls
 // to handled topics or putting the emitted messages in the emitted-messages-list
-func (p *producerMock) EmitWithHeaders(topic string, key string, value []byte, header headers.Headers) *goka.Promise {
+func (p *producerMock) EmitWithHeaders(topic string, key string, value []byte, header goka.Headers) *goka.Promise {
 	return p.emitter(topic, key, value, WithHeaders(header))
 }
 
@@ -48,7 +47,7 @@ type flushingProducer struct {
 }
 
 // Emit using the underlying producer
-func (e *flushingProducer) EmitWithHeaders(topic string, key string, value []byte, header headers.Headers) *goka.Promise {
+func (e *flushingProducer) EmitWithHeaders(topic string, key string, value []byte, header goka.Headers) *goka.Promise {
 	prom := e.producer.EmitWithHeaders(topic, key, value, header)
 	e.tester.waitForClients()
 	return prom

--- a/tester/queue.go
+++ b/tester/queue.go
@@ -1,17 +1,17 @@
 package tester
 
 import (
-	"github.com/lovoo/goka/headers"
 	"sync"
 
 	"github.com/Shopify/sarama"
+	"github.com/lovoo/goka"
 )
 
 type message struct {
 	offset  int64
 	key     string
 	value   []byte
-	headers headers.Headers
+	headers goka.Headers
 }
 
 // Convert message headers to an array of SaramaHeaders
@@ -48,7 +48,7 @@ func (q *queue) Hwm() int64 {
 	return hwm
 }
 
-func (q *queue) push(key string, value []byte, hdr headers.Headers) int64 {
+func (q *queue) push(key string, value []byte, hdr goka.Headers) int64 {
 	q.Lock()
 	defer q.Unlock()
 	offset := q.hwm
@@ -109,7 +109,7 @@ func (mt *QueueTracker) Next() (string, interface{}, bool) {
 // NextWithHeaders returns the next message since the last time this
 // function was called (or MoveToEnd).  This includes headers
 // It uses the known codec for the topic to decode the message
-func (mt *QueueTracker) NextWithHeaders() (headers.Headers, string, interface{}, bool) {
+func (mt *QueueTracker) NextWithHeaders() (goka.Headers, string, interface{}, bool) {
 	hdr, key, msgRaw, hasNext := mt.NextRawWithHeaders()
 
 	if !hasNext {
@@ -130,10 +130,10 @@ func (mt *QueueTracker) NextRaw() (string, []byte, bool) {
 }
 
 // NextRawWithHeaders returns the next message similar to Next(), but without the decoding
-func (mt *QueueTracker) NextRawWithHeaders() (headers.Headers, string, []byte, bool) {
+func (mt *QueueTracker) NextRawWithHeaders() (goka.Headers, string, []byte, bool) {
 	q := mt.tester.getOrCreateQueue(mt.topic)
 	if int(mt.nextOffset) >= q.size() {
-		return headers.Headers{}, "", nil, false
+		return goka.Headers{}, "", nil, false
 	}
 	msg := q.message(int(mt.nextOffset))
 

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -2,7 +2,6 @@ package tester
 
 import (
 	"fmt"
-	"github.com/lovoo/goka/headers"
 	"hash"
 	"reflect"
 	"sync"
@@ -14,17 +13,17 @@ import (
 )
 
 type emitOption struct {
-	headers headers.Headers
+	headers goka.Headers
 }
 
 // EmitOption defines a configuration option for emitting messages
 type EmitOption func(*emitOption)
 
 // WithHeaders sets kafka headers to use when emitting to kafka
-func WithHeaders(hdr headers.Headers) EmitOption {
+func WithHeaders(hdr goka.Headers) EmitOption {
 	return func(opts *emitOption) {
 		if opts.headers == nil {
-			opts.headers = make(headers.Headers)
+			opts.headers = make(goka.Headers)
 		}
 
 		for k, v := range hdr {
@@ -165,7 +164,7 @@ func (tt *Tester) handleEmit(topic string, key string, value []byte, options ...
 	return finisher(&sarama.ProducerMessage{Offset: offset}, nil)
 }
 
-func (tt *Tester) pushMessage(topic string, key string, data []byte, hdr headers.Headers) int64 {
+func (tt *Tester) pushMessage(topic string, key string, data []byte, hdr goka.Headers) int64 {
 	return tt.getOrCreateQueue(topic).push(key, data, hdr)
 }
 


### PR DESCRIPTION
No functional or breaking changes. Mostly a find/replace exercise. The meat of it is the ability for users to write `goka.Headers` instead of `headers.Headers` if they choose to.

The choice of implementing it using a type alias is two folds:
- There is little value in introducing an `interface` type definition to the mix since users are not expected to provide implementations.
- Introducing the interface type alongside the struct type `headers.Headers` requires some quirks to avoid cyclic imports between `goka` and `headers` packages. Not worth it.

Closes #322 