### PR TITLE
Added GetTableKeys to tester

### DIFF
--- a/integrationtest/view_test.go
+++ b/integrationtest/view_test.go
@@ -39,13 +39,25 @@ func TestView(t *testing.T) {
 
 		// try to get some non-existent key
 		val, err = view.Get("not-existent")
+		test.AssertNil(t, err)
 		test.AssertNil(t, val)
 		test.AssertNil(t, nil)
 
 		// get the value we set earlier
 		val, err = view.Get("key")
+		test.AssertNil(t, err)
 		test.AssertEqual(t, val.(string), "value")
 		test.AssertNil(t, nil)
+
+		// get all the keys from table "test"
+		keys := gkt.GetTableKeys("test")
+		// at the moment we only have one key "key"
+		test.AssertEqual(t, keys, []string{"key"})
+
+		// set a second key
+		gkt.SetTableValue("test", "key2", "value")
+		keys = gkt.GetTableKeys("test")
+		test.AssertEqual(t, keys, []string{"key", "key2"})
 
 		// stop the view and wait for it to finish up
 		cancel()

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -383,6 +383,26 @@ func (tt *Tester) waitForClients() {
 	logger.Printf("waiting for consumers done")
 }
 
+// GetTableKeys returns a Table's keys.
+func (tt *Tester) GetTableKeys(table goka.Table) []string {
+	tt.mStorages.Lock()
+	defer tt.mStorages.Unlock()
+
+	keys := make([]string, 0)
+	topic := string(table)
+	st, exists := tt.storages[topic]
+	if !exists {
+		panic(fmt.Errorf("topic %s does not exist", topic))
+	}
+
+	it, _ := st.Iterator()
+	for it.Next() {
+		keys = append(keys, string(it.Key()))
+	}
+
+	return keys
+}
+
 // Consume pushes a message for topic/key to be consumed by all processors/views
 // whoever is using it being registered to the Tester
 func (tt *Tester) Consume(topic string, key string, msg interface{}, options ...EmitOption) {

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -392,10 +392,11 @@ func (tt *Tester) GetTableKeys(table goka.Table) []string {
 	topic := string(table)
 	st, exists := tt.storages[topic]
 	if !exists {
-		panic(fmt.Errorf("topic %s does not exist", topic))
+		tt.t.Fatalf("topic %s does not exist", topic)
 	}
 
 	it, _ := st.Iterator()
+	defer it.Release()
 	for it.Next() {
 		keys = append(keys, string(it.Key()))
 	}


### PR DESCRIPTION
This PR adds a function `GetTableKeys` that returns a tester Table's list of keys.