### PR TITLE
Expose Processor State With StateReader Interface

### DIFF
--- a/partition_table.go
+++ b/partition_table.go
@@ -667,7 +667,7 @@ func (p *PartitionTable) CurrentState() PartitionStatus {
 }
 
 // WaitRecovered returns a channel that closes when the partition table enters state `PartitionRunning`
-func (p *PartitionTable) WaitRecovered() chan struct{} {
+func (p *PartitionTable) WaitRecovered() <-chan struct{} {
 	return p.state.WaitForState(State(PartitionRunning))
 }
 

--- a/processor.go
+++ b/processor.go
@@ -530,6 +530,11 @@ func (g *Processor) Recovered() bool {
 	return g.state.IsState(ProcStateRunning)
 }
 
+// StateReader returns a read only interface of the processors state.
+func (g *Processor) StateReader() StateReader {
+	return g.state
+}
+
 func (g *Processor) assignmentFromSession(session sarama.ConsumerGroupSession) (Assignment, error) {
 	var (
 		assignment Assignment

--- a/processor_test.go
+++ b/processor_test.go
@@ -312,3 +312,11 @@ func TestProcessor_Run(t *testing.T) {
 		test.AssertTrue(t, strings.Contains(procErr.Error(), "setup-error"))
 	})
 }
+
+func TestProcessor_StateReader(t *testing.T) {
+	state := NewSignal(ProcStateSetup, ProcStateRunning)
+	state.SetState(ProcStateRunning)
+	p := Processor{state: state}
+
+	test.AssertEqual(t, p.StateReader().State(), ProcStateRunning)
+}

--- a/signal.go
+++ b/signal.go
@@ -14,6 +14,12 @@ type waiter struct {
 	minState bool
 }
 
+// StateReader is a read only abstraction of a Signal to expose the current state.
+type StateReader interface {
+	State() State
+	WaitForState(state State) <-chan struct{}
+}
+
 // Signal allows synchronization on a state, waiting for that state and checking
 // the current state
 type Signal struct {
@@ -100,7 +106,7 @@ func (s *Signal) WaitForStateMin(state State) chan struct{} {
 
 // WaitForState returns a channel that closes when the signal reaches passed
 // state.
-func (s *Signal) WaitForState(state State) chan struct{} {
+func (s *Signal) WaitForState(state State) <-chan struct{} {
 
 	w := &waiter{
 		done:  make(chan struct{}),


### PR DESCRIPTION
Closes #343 
- add a `StateReader` to the processor to expose the current state.
- `PartitionTable.WaitRecovered()` now returns a read only channel.