### PR TITLE
bugfix backoff: add max-wait, actually use parameter

### DIFF
--- a/builders.go
+++ b/builders.go
@@ -2,7 +2,6 @@ package goka
 
 import (
 	"hash"
-	"time"
 
 	"github.com/Shopify/sarama"
 )
@@ -93,7 +92,7 @@ func SaramaConsumerBuilderWithConfig(config *sarama.Config) SaramaConsumerBuilde
 // BackoffBuilder creates a backoff
 type BackoffBuilder func() (Backoff, error)
 
-// DefaultBackoffBuilder returnes a simpleBackoff with 10 second steps
+// DefaultBackoffBuilder returnes a simpleBackoff with 10 seconds step increase and 2 minutes max wait
 func DefaultBackoffBuilder() (Backoff, error) {
-	return NewSimpleBackoff(time.Second * 10), nil
+	return NewSimpleBackoff(defaultBackoffStep, defaultBackoffMax), nil
 }

--- a/options.go
+++ b/options.go
@@ -43,7 +43,13 @@ type RebalanceCallback func(a Assignment)
 const (
 	defaultBaseStoragePath = "/tmp/goka"
 	defaultClientID        = "goka"
-	defaultBackoffRestTime = time.Minute
+
+	// duration, after which we'll reset the backoff
+	defaultBackoffResetTime = 60 * time.Second
+	// duration to increase each time retrying
+	defaultBackoffStep = 10 * time.Second
+	// maximum duration to wait for the backoff
+	defaultBackoffMax = 120 * time.Second
 )
 
 // DefaultProcessorStoragePath is the default path where processor state
@@ -323,7 +329,7 @@ func (opt *poptions) applyOptions(gg *GroupGraph, opts ...ProcessorOption) error
 	opt.clientID = defaultClientID
 	opt.log = defaultLogger
 	opt.hasher = DefaultHasher()
-	opt.backoffResetTime = defaultBackoffRestTime
+	opt.backoffResetTime = defaultBackoffResetTime
 
 	for _, o := range opts {
 		o(opt, gg)
@@ -494,7 +500,7 @@ func (opt *voptions) applyOptions(topic Table, codec Codec, opts ...ViewOption) 
 	opt.clientID = defaultClientID
 	opt.log = defaultLogger
 	opt.hasher = DefaultHasher()
-	opt.backoffResetTime = defaultBackoffRestTime
+	opt.backoffResetTime = defaultBackoffResetTime
 
 	for _, o := range opts {
 		o(opt, topic, codec)

--- a/partition_processor.go
+++ b/partition_processor.go
@@ -232,7 +232,7 @@ func (pp *PartitionProcessor) Start(setupCtx, ctx context.Context) error {
 			pp.opts.updateCallback,
 			pp.opts.builders.storage,
 			pp.log.Prefix(fmt.Sprintf("Join %s", join.Topic())),
-			NewSimpleBackoff(time.Second*10),
+			NewSimpleBackoff(defaultBackoffStep, defaultBackoffMax),
 			time.Minute,
 		)
 		pp.joins[join.Topic()] = table

--- a/simple_backoff.go
+++ b/simple_backoff.go
@@ -4,15 +4,17 @@ import "time"
 
 // NewSimpleBackoff returns a simple backoff waiting the
 // specified duration longer each iteration until reset.
-func NewSimpleBackoff(step time.Duration) Backoff {
+func NewSimpleBackoff(step time.Duration, max time.Duration) Backoff {
 	return &simpleBackoff{
-		step: time.Second,
+		step: step,
+		max:  max,
 	}
 }
 
 type simpleBackoff struct {
 	current time.Duration
 	step    time.Duration
+	max     time.Duration
 }
 
 func (b *simpleBackoff) Reset() {
@@ -20,6 +22,10 @@ func (b *simpleBackoff) Reset() {
 }
 
 func (b *simpleBackoff) Duration() time.Duration {
-	b.current += b.step
-	return b.current
+	value := b.current
+
+	if (b.current + b.step) <= b.max {
+		b.current += b.step
+	}
+	return value
 }

--- a/simple_backoff_test.go
+++ b/simple_backoff_test.go
@@ -9,18 +9,22 @@ import (
 
 func TestSimpleBackoff(t *testing.T) {
 	t.Run("simple progression", func(t *testing.T) {
-		backoff := NewSimpleBackoff(time.Second)
+		backoff := NewSimpleBackoff(time.Second, 10*time.Second)
 		for i := 0; i < 10; i++ {
-			test.AssertEqual(t, time.Duration(i+1)*time.Second, backoff.Duration())
+			test.AssertEqual(t, time.Duration(i)*time.Second, backoff.Duration())
 		}
+
+		// it doesn't go higher than the max
+		test.AssertEqual(t, 10*time.Second, backoff.Duration())
+		test.AssertEqual(t, 10*time.Second, backoff.Duration())
 	})
 	t.Run("reset", func(t *testing.T) {
-		backoff := NewSimpleBackoff(time.Second)
-		for i := 0; i < 10; i++ {
-			if i%5 == 0 {
-				backoff.Reset()
-			}
-			test.AssertEqual(t, time.Duration(i%5+1)*time.Second, backoff.Duration())
-		}
+		backoff := NewSimpleBackoff(time.Second, 10*time.Second)
+
+		test.AssertEqual(t, backoff.Duration(), time.Duration(0))
+		backoff.Duration()
+		test.AssertTrue(t, backoff.Duration() != 0)
+		backoff.Reset()
+		test.AssertEqual(t, backoff.Duration(), time.Duration(0))
 	})
 }

--- a/view_test.go
+++ b/view_test.go
@@ -540,7 +540,7 @@ func TestView_Run(t *testing.T) {
 			updateCB,
 			bm.getStorageBuilder(),
 			defaultLogger,
-			NewSimpleBackoff(time.Second*10),
+			NewSimpleBackoff(defaultBackoffStep, defaultBackoffMax),
 			time.Minute,
 		)
 
@@ -595,7 +595,7 @@ func TestView_Run(t *testing.T) {
 			updateCB,
 			bm.getStorageBuilder(),
 			defaultLogger,
-			NewSimpleBackoff(time.Second*10),
+			NewSimpleBackoff(defaultBackoffStep, defaultBackoffMax),
 			time.Minute,
 		)
 


### PR DESCRIPTION
We use a simple backoff-mechanism for reconnecting views. That implementation had some isues that are fixed now:

* actually use the backoff-step-parameter
* add a max-wait parameter. Otherwise if the backoff would grow indefinitely and won't reconnect in reasonable time, when Kafka was offline for too long.