### PR TITLE
Fix examples initialization after auto creation of topics is disabled

### DIFF
--- a/examples/1-simplest/main.go
+++ b/examples/1-simplest/main.go
@@ -112,6 +112,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error creating topic manager: %v", err)
 	}
+	defer tm.Close()
 	err = tm.EnsureStreamExists(string(topic), 8)
 	if err != nil {
 		log.Printf("Error creating kafka topic %s: %v", topic, err)

--- a/examples/10-visit/main.go
+++ b/examples/10-visit/main.go
@@ -59,6 +59,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error creating topic manager: %v", err)
 	}
+	defer tm.Close()
 	err = tm.EnsureStreamExists(string(topic), 8)
 	if err != nil {
 		log.Fatalf("Error creating kafka topic %s: %v", topic, err)

--- a/examples/2-clicks/main.go
+++ b/examples/2-clicks/main.go
@@ -138,6 +138,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error creating topic manager: %v", err)
 	}
+	defer tm.Close()
 	err = tm.EnsureStreamExists(string(topic), 8)
 	if err != nil {
 		log.Printf("Error creating kafka topic %s: %v", topic, err)

--- a/examples/3-messaging/README.md
+++ b/examples/3-messaging/README.md
@@ -96,7 +96,7 @@ func collect(ctx goka.Context, msg interface{}) {
 	ml = append(ml, *m)
 
 	if len(ml) > maxMessages {
-		ml = ml[len(ml)-maxMessages-1:]
+		ml = ml[len(ml)-maxMessages:]
 	}
 	ctx.SetValue(ml)
 }

--- a/examples/3-messaging/blocker/blocker.go
+++ b/examples/3-messaging/blocker/blocker.go
@@ -61,9 +61,10 @@ func block(ctx goka.Context, msg interface{}) {
 }
 
 func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
-	return func() error {
-		topicinit.EnsureStreamExists(string(Stream), brokers)
+	// to prevent race conditions we ensure that topics exist before the execution of the Goroutine
+	topicinit.EnsureStreamExists(string(Stream), brokers)
 
+	return func() error {
 		g := goka.DefineGroup(group,
 			goka.Input(Stream, new(BlockEventCodec), block),
 			goka.Persist(new(BlockValueCodec)),

--- a/examples/3-messaging/blocker/blocker.go
+++ b/examples/3-messaging/blocker/blocker.go
@@ -3,7 +3,7 @@ package blocker
 import (
 	"context"
 	"encoding/json"
-	"github.com/lovoo/goka/examples/3-messaging/topic"
+	"github.com/lovoo/goka/examples/3-messaging/topicinit"
 	"sync"
 
 	"github.com/lovoo/goka"
@@ -62,7 +62,7 @@ func block(ctx goka.Context, msg interface{}) {
 
 func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
 	return func() error {
-		topic.EnsureStreamExists(string(Stream), brokers)
+		topicinit.EnsureStreamExists(string(Stream), brokers)
 
 		g := goka.DefineGroup(group,
 			goka.Input(Stream, new(BlockEventCodec), block),

--- a/examples/3-messaging/cmd/processor/main.go
+++ b/examples/3-messaging/cmd/processor/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 
 	"github.com/lovoo/goka/examples/3-messaging/blocker"
@@ -32,43 +31,42 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	grp, ctx := errgroup.WithContext(ctx)
 
-	// When this example is run the first time, wait for creation of all internal topics
-	initialized := sync.WaitGroup{}
+	// Create topics if they do not already exist
 	if *runCollector {
-		initialized.Add(1)
+		collector.PrepareTopics(brokers)
 	}
 	if *runFilter {
-		initialized.Add(1)
+		filter.PrepareTopics(brokers)
 	}
 	if *runBlocker {
-		initialized.Add(1)
+		blocker.PrepareTopics(brokers)
 	}
 	if *runDetector {
-		initialized.Add(1)
+		detector.PrepareTopics(brokers)
 	}
 	if *runTranslator {
-		initialized.Add(1)
+		translator.PrepareTopics(brokers)
 	}
 
 	if *runCollector {
 		log.Println("starting collector")
-		grp.Go(collector.Run(ctx, brokers, &initialized))
+		grp.Go(collector.Run(ctx, brokers))
 	}
 	if *runFilter {
 		log.Println("starting filter")
-		grp.Go(filter.Run(ctx, brokers, &initialized))
+		grp.Go(filter.Run(ctx, brokers))
 	}
 	if *runBlocker {
 		log.Println("starting blocker")
-		grp.Go(blocker.Run(ctx, brokers, &initialized))
+		grp.Go(blocker.Run(ctx, brokers))
 	}
 	if *runDetector {
 		log.Println("starting detector")
-		grp.Go(detector.Run(ctx, brokers, &initialized))
+		grp.Go(detector.Run(ctx, brokers))
 	}
 	if *runTranslator {
 		log.Println("starting translator")
-		grp.Go(translator.Run(ctx, brokers, &initialized))
+		grp.Go(translator.Run(ctx, brokers))
 	}
 
 	// Wait for SIGINT/SIGTERM

--- a/examples/3-messaging/collector/collector.go
+++ b/examples/3-messaging/collector/collector.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/examples/3-messaging"
-	"github.com/lovoo/goka/examples/3-messaging/topic"
+	"github.com/lovoo/goka/examples/3-messaging/topicinit"
 	"sync"
 )
 
@@ -45,7 +45,7 @@ func collect(ctx goka.Context, msg interface{}) {
 
 func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
 	return func() error {
-		topic.EnsureStreamExists(string(messaging.ReceivedStream), brokers)
+		topicinit.EnsureStreamExists(string(messaging.ReceivedStream), brokers)
 
 		g := goka.DefineGroup(group,
 			goka.Input(messaging.ReceivedStream, new(messaging.MessageCodec), collect),

--- a/examples/3-messaging/collector/collector.go
+++ b/examples/3-messaging/collector/collector.go
@@ -44,9 +44,10 @@ func collect(ctx goka.Context, msg interface{}) {
 }
 
 func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
-	return func() error {
-		topicinit.EnsureStreamExists(string(messaging.ReceivedStream), brokers)
+	// to prevent race conditions we ensure that topics exist before the execution of the Goroutine
+	topicinit.EnsureStreamExists(string(messaging.ReceivedStream), brokers)
 
+	return func() error {
 		g := goka.DefineGroup(group,
 			goka.Input(messaging.ReceivedStream, new(messaging.MessageCodec), collect),
 			goka.Persist(new(MessageListCodec)),

--- a/examples/3-messaging/collector/collector.go
+++ b/examples/3-messaging/collector/collector.go
@@ -3,9 +3,10 @@ package collector
 import (
 	"context"
 	"encoding/json"
-
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/examples/3-messaging"
+	"github.com/lovoo/goka/examples/3-messaging/topic"
+	"sync"
 )
 
 const maxMessages = 5
@@ -42,16 +43,25 @@ func collect(ctx goka.Context, msg interface{}) {
 	ctx.SetValue(ml)
 }
 
-func Run(ctx context.Context, brokers []string) func() error {
+func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
 	return func() error {
+		topic.EnsureStreamExists(string(messaging.ReceivedStream), brokers)
+
 		g := goka.DefineGroup(group,
 			goka.Input(messaging.ReceivedStream, new(messaging.MessageCodec), collect),
 			goka.Persist(new(MessageListCodec)),
 		)
 		p, err := goka.NewProcessor(brokers, g)
 		if err != nil {
+			// we have to signal done here so other Goroutines of the errgroup
+			// can continue execution
+			initialized.Done()
 			return err
 		}
+
+		initialized.Done()
+		initialized.Wait()
+
 		return p.Run(ctx)
 	}
 }

--- a/examples/3-messaging/detector/detector.go
+++ b/examples/3-messaging/detector/detector.go
@@ -52,9 +52,10 @@ func detectSpammer(ctx goka.Context, c *Counters) bool {
 }
 
 func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
-	return func() error {
-		topicinit.EnsureStreamExists(string(messaging.SentStream), brokers)
+	// to prevent race conditions we ensure that topics exist before the execution of the Goroutine
+	topicinit.EnsureStreamExists(string(messaging.SentStream), brokers)
 
+	return func() error {
 		g := goka.DefineGroup(group,
 			goka.Input(messaging.SentStream, new(messaging.MessageCodec), func(ctx goka.Context, msg interface{}) {
 				c := getValue(ctx)

--- a/examples/3-messaging/detector/detector.go
+++ b/examples/3-messaging/detector/detector.go
@@ -3,6 +3,8 @@ package detector
 import (
 	"context"
 	"encoding/json"
+	"github.com/lovoo/goka/examples/3-messaging/topic"
+	"sync"
 
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/examples/3-messaging"
@@ -49,8 +51,10 @@ func detectSpammer(ctx goka.Context, c *Counters) bool {
 	return total >= minMessages && rate >= maxRate
 }
 
-func Run(ctx context.Context, brokers []string) func() error {
+func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
 	return func() error {
+		topic.EnsureStreamExists(string(messaging.SentStream), brokers)
+
 		g := goka.DefineGroup(group,
 			goka.Input(messaging.SentStream, new(messaging.MessageCodec), func(ctx goka.Context, msg interface{}) {
 				c := getValue(ctx)
@@ -81,8 +85,14 @@ func Run(ctx context.Context, brokers []string) func() error {
 		)
 		p, err := goka.NewProcessor(brokers, g)
 		if err != nil {
+			// we have to signal done here so other Goroutines of the errgroup
+			// can continue execution
+			initialized.Done()
 			return err
 		}
+
+		initialized.Done()
+		initialized.Wait()
 
 		return p.Run(ctx)
 	}

--- a/examples/3-messaging/detector/detector.go
+++ b/examples/3-messaging/detector/detector.go
@@ -3,7 +3,7 @@ package detector
 import (
 	"context"
 	"encoding/json"
-	"github.com/lovoo/goka/examples/3-messaging/topic"
+	"github.com/lovoo/goka/examples/3-messaging/topicinit"
 	"sync"
 
 	"github.com/lovoo/goka"
@@ -53,7 +53,7 @@ func detectSpammer(ctx goka.Context, c *Counters) bool {
 
 func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
 	return func() error {
-		topic.EnsureStreamExists(string(messaging.SentStream), brokers)
+		topicinit.EnsureStreamExists(string(messaging.SentStream), brokers)
 
 		g := goka.DefineGroup(group,
 			goka.Input(messaging.SentStream, new(messaging.MessageCodec), func(ctx goka.Context, msg interface{}) {

--- a/examples/3-messaging/filter/filter.go
+++ b/examples/3-messaging/filter/filter.go
@@ -2,7 +2,7 @@ package filter
 
 import (
 	"context"
-	"github.com/lovoo/goka/examples/3-messaging/topic"
+	"github.com/lovoo/goka/examples/3-messaging/topicinit"
 	"strings"
 	"sync"
 
@@ -45,12 +45,12 @@ func translate(ctx goka.Context, m *messaging.Message) *messaging.Message {
 
 func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
 	return func() error {
-		topic.EnsureStreamExists(string(messaging.SentStream), brokers)
+		topicinit.EnsureStreamExists(string(messaging.SentStream), brokers)
 
 		// We refer to these tables, ensure that they exist initially also in the
 		// case if the translator or blocker processors are not started
 		for _, topicName := range []string{string(translator.Table), string(blocker.Table)} {
-			topic.EnsureTableExists(topicName, brokers)
+			topicinit.EnsureTableExists(topicName, brokers)
 		}
 
 		g := goka.DefineGroup(group,

--- a/examples/3-messaging/topic/topic.go
+++ b/examples/3-messaging/topic/topic.go
@@ -1,0 +1,33 @@
+package topic
+
+import (
+	"github.com/lovoo/goka"
+	"log"
+)
+
+// EnsureStreamExists is a convenience wrapper for TopicManager.EnsureStreamExists
+func EnsureStreamExists(topic string, brokers []string) {
+	tm := createTopicManager(brokers)
+	err := tm.EnsureStreamExists(topic, 8)
+	if err != nil {
+		log.Printf("Error creating kafka topic %s: %v", topic, err)
+	}
+}
+
+// EnsureStreamExists is a convenience wrapper for TopicManager.EnsureTableExists
+func EnsureTableExists(topic string, brokers []string) {
+	tm := createTopicManager(brokers)
+	err := tm.EnsureTableExists(topic, 8)
+	if err != nil {
+		log.Printf("Error creating kafka topic %s: %v", topic, err)
+	}
+}
+
+func createTopicManager(brokers []string) goka.TopicManager {
+	tmc := goka.NewTopicManagerConfig()
+	tm, err := goka.NewTopicManager(brokers, goka.DefaultConfig(), tmc)
+	if err != nil {
+		log.Fatalf("Error creating topic manager: %v", err)
+	}
+	return tm
+}

--- a/examples/3-messaging/topicinit/topicinit.go
+++ b/examples/3-messaging/topicinit/topicinit.go
@@ -1,4 +1,4 @@
-package topic
+package topicinit
 
 import (
 	"github.com/lovoo/goka"

--- a/examples/3-messaging/topicinit/topicinit.go
+++ b/examples/3-messaging/topicinit/topicinit.go
@@ -14,7 +14,7 @@ func EnsureStreamExists(topic string, brokers []string) {
 	}
 }
 
-// EnsureStreamExists is a convenience wrapper for TopicManager.EnsureTableExists
+// EnsureTableExists is a convenience wrapper for TopicManager.EnsureTableExists
 func EnsureTableExists(topic string, brokers []string) {
 	tm := createTopicManager(brokers)
 	err := tm.EnsureTableExists(topic, 8)

--- a/examples/3-messaging/topicinit/topicinit.go
+++ b/examples/3-messaging/topicinit/topicinit.go
@@ -8,6 +8,7 @@ import (
 // EnsureStreamExists is a convenience wrapper for TopicManager.EnsureStreamExists
 func EnsureStreamExists(topic string, brokers []string) {
 	tm := createTopicManager(brokers)
+	defer tm.Close()
 	err := tm.EnsureStreamExists(topic, 8)
 	if err != nil {
 		log.Printf("Error creating kafka topic %s: %v", topic, err)
@@ -17,6 +18,7 @@ func EnsureStreamExists(topic string, brokers []string) {
 // EnsureTableExists is a convenience wrapper for TopicManager.EnsureTableExists
 func EnsureTableExists(topic string, brokers []string) {
 	tm := createTopicManager(brokers)
+	defer tm.Close()
 	err := tm.EnsureTableExists(topic, 8)
 	if err != nil {
 		log.Printf("Error creating kafka topic %s: %v", topic, err)

--- a/examples/3-messaging/translator/translator.go
+++ b/examples/3-messaging/translator/translator.go
@@ -2,7 +2,7 @@ package translator
 
 import (
 	"context"
-	"github.com/lovoo/goka/examples/3-messaging/topic"
+	"github.com/lovoo/goka/examples/3-messaging/topicinit"
 	"sync"
 
 	"github.com/lovoo/goka"
@@ -25,8 +25,8 @@ func translate(ctx goka.Context, msg interface{}) {
 
 func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
 	return func() error {
-		topic.EnsureStreamExists(string(group), brokers)
-		topic.EnsureStreamExists(string(Stream), brokers)
+		topicinit.EnsureStreamExists(string(group), brokers)
+		topicinit.EnsureStreamExists(string(Stream), brokers)
 
 		g := goka.DefineGroup(group,
 			goka.Input(Stream, new(ValueCodec), translate),

--- a/examples/3-messaging/translator/translator.go
+++ b/examples/3-messaging/translator/translator.go
@@ -2,11 +2,9 @@ package translator
 
 import (
 	"context"
-	"github.com/lovoo/goka/examples/3-messaging/topicinit"
-	"sync"
-
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/codec"
+	"github.com/lovoo/goka/examples/3-messaging/topicinit"
 )
 
 var (
@@ -23,11 +21,11 @@ func translate(ctx goka.Context, msg interface{}) {
 	ctx.SetValue(msg.(string))
 }
 
-func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
-	// to prevent race conditions we ensure that topics exist before the execution of the Goroutine
-	topicinit.EnsureStreamExists(string(group), brokers)
+func PrepareTopics(brokers []string) {
 	topicinit.EnsureStreamExists(string(Stream), brokers)
+}
 
+func Run(ctx context.Context, brokers []string) func() error {
 	return func() error {
 		g := goka.DefineGroup(group,
 			goka.Input(Stream, new(ValueCodec), translate),
@@ -35,14 +33,8 @@ func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) fun
 		)
 		p, err := goka.NewProcessor(brokers, g)
 		if err != nil {
-			// we have to signal done here so other Goroutines of the errgroup
-			// can continue execution
-			initialized.Done()
 			return err
 		}
-
-		initialized.Done()
-		initialized.Wait()
 
 		return p.Run(ctx)
 	}

--- a/examples/3-messaging/translator/translator.go
+++ b/examples/3-messaging/translator/translator.go
@@ -24,10 +24,11 @@ func translate(ctx goka.Context, msg interface{}) {
 }
 
 func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
-	return func() error {
-		topicinit.EnsureStreamExists(string(group), brokers)
-		topicinit.EnsureStreamExists(string(Stream), brokers)
+	// to prevent race conditions we ensure that topics exist before the execution of the Goroutine
+	topicinit.EnsureStreamExists(string(group), brokers)
+	topicinit.EnsureStreamExists(string(Stream), brokers)
 
+	return func() error {
 		g := goka.DefineGroup(group,
 			goka.Input(Stream, new(ValueCodec), translate),
 			goka.Persist(new(ValueCodec)),

--- a/examples/3-messaging/translator/translator.go
+++ b/examples/3-messaging/translator/translator.go
@@ -2,6 +2,8 @@ package translator
 
 import (
 	"context"
+	"github.com/lovoo/goka/examples/3-messaging/topic"
+	"sync"
 
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/codec"
@@ -21,16 +23,26 @@ func translate(ctx goka.Context, msg interface{}) {
 	ctx.SetValue(msg.(string))
 }
 
-func Run(ctx context.Context, brokers []string) func() error {
+func Run(ctx context.Context, brokers []string, initialized *sync.WaitGroup) func() error {
 	return func() error {
+		topic.EnsureStreamExists(string(group), brokers)
+		topic.EnsureStreamExists(string(Stream), brokers)
+
 		g := goka.DefineGroup(group,
 			goka.Input(Stream, new(ValueCodec), translate),
 			goka.Persist(new(ValueCodec)),
 		)
 		p, err := goka.NewProcessor(brokers, g)
 		if err != nil {
+			// we have to signal done here so other Goroutines of the errgroup
+			// can continue execution
+			initialized.Done()
 			return err
 		}
+
+		initialized.Done()
+		initialized.Wait()
+
 		return p.Run(ctx)
 	}
 }

--- a/examples/5-multiple/main.go
+++ b/examples/5-multiple/main.go
@@ -125,6 +125,7 @@ func runProcessor(ctx context.Context,
 	if err != nil {
 		log.Fatalf("Error creating topic manager: %v", err)
 	}
+	defer tm.Close()
 	for _, topicName := range []string{string(inputA), string(inputB)} {
 		err = tm.EnsureStreamExists(topicName, 8)
 		if err != nil {

--- a/examples/5-multiple/main.go
+++ b/examples/5-multiple/main.go
@@ -123,6 +123,9 @@ func runProcessor(ctx context.Context, monitor *monitor.Server, query *query.Ser
 	),
 		goka.WithStorageBuilder(randomStorageBuilder("proc")),
 	)
+	if err != nil {
+		return err
+	}
 
 	// attach the processor to the monitor
 	monitor.AttachProcessor(p)

--- a/examples/5-multiple/main.go
+++ b/examples/5-multiple/main.go
@@ -115,7 +115,23 @@ func process(ctx goka.Context, msg interface{}) {
 	ctx.SetValue(u)
 }
 
-func runProcessor(ctx context.Context, monitor *monitor.Server, query *query.Server) error {
+func runProcessor(ctx context.Context,
+	monitor *monitor.Server,
+	query *query.Server,
+	groupInitialized chan struct{}) error {
+
+	tmc := goka.NewTopicManagerConfig()
+	tm, err := goka.NewTopicManager(brokers, goka.DefaultConfig(), tmc)
+	if err != nil {
+		log.Fatalf("Error creating topic manager: %v", err)
+	}
+	for _, topicName := range []string{string(inputA), string(inputB)} {
+		err = tm.EnsureStreamExists(topicName, 8)
+		if err != nil {
+			log.Printf("Error creating kafka topic %s: %v", topicName, err)
+		}
+	}
+
 	p, err := goka.NewProcessor(brokers, goka.DefineGroup(group,
 		goka.Input(inputA, new(codec.String), process),
 		goka.Input(inputB, new(codec.String), process),
@@ -126,6 +142,8 @@ func runProcessor(ctx context.Context, monitor *monitor.Server, query *query.Ser
 	if err != nil {
 		return err
 	}
+
+	close(groupInitialized)
 
 	// attach the processor to the monitor
 	monitor.AttachProcessor(p)
@@ -138,7 +156,14 @@ func runProcessor(ctx context.Context, monitor *monitor.Server, query *query.Ser
 	return err
 }
 
-func runView(ctx context.Context, errg *multierr.ErrGroup, root *mux.Router, monitor *monitor.Server) error {
+func runView(ctx context.Context,
+	errg *multierr.ErrGroup,
+	root *mux.Router,
+	monitor *monitor.Server,
+	groupInitialized chan struct{}) error {
+
+	<-groupInitialized
+
 	view, err := goka.NewView(brokers,
 		goka.GroupTable(group),
 		new(userCodec),
@@ -223,6 +248,9 @@ func main() {
 		cancel()
 	}()
 
+	// runView uses the group table, which first has to be initialized by runProcessor
+	groupInitialized := make(chan struct{})
+
 	errg, ctx := multierr.NewErrGroup(ctx)
 	errg.Go(func() error {
 		defer log.Printf("emitter done")
@@ -230,9 +258,9 @@ func main() {
 	})
 	errg.Go(func() error {
 		defer log.Printf("processor done")
-		return runProcessor(ctx, monitorServer, queryServer)
+		return runProcessor(ctx, monitorServer, queryServer, groupInitialized)
 	})
-	if err := runView(ctx, errg, root, monitorServer); err != nil {
+	if err := runView(ctx, errg, root, monitorServer, groupInitialized); err != nil {
 		log.Printf("Error running view, will shutdown: %v", err)
 		cancel()
 	}

--- a/examples/6-reconnecting-view/main.go
+++ b/examples/6-reconnecting-view/main.go
@@ -12,12 +12,24 @@ import (
 )
 
 func main() {
+	var brokers = []string{"127.0.0.1:9092"}
+	var topic goka.Table = "restartable-view-test-table"
+
+	tmc := goka.NewTopicManagerConfig()
+	tm, err := goka.NewTopicManager(brokers, goka.DefaultConfig(), tmc)
+	if err != nil {
+		log.Fatalf("Error creating topic manager: %v", err)
+	}
+	err = tm.EnsureStreamExists(string(topic), 8)
+	if err != nil {
+		log.Printf("Error creating kafka topic %s: %v", topic, err)
+	}
 
 	view, err := goka.NewView(
 		// connect to example kafka cluster
 		[]string{"localhost:9092"},
 		// name does not matter, table will be empty
-		"restartable-view-test-table",
+		topic,
 		// codec doesn't matter, the table will be empty
 		new(codec.String),
 		// start the view autoconnecting

--- a/examples/6-reconnecting-view/main.go
+++ b/examples/6-reconnecting-view/main.go
@@ -20,6 +20,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error creating topic manager: %v", err)
 	}
+	defer tm.Close()
 	err = tm.EnsureStreamExists(string(topic), 8)
 	if err != nil {
 		log.Printf("Error creating kafka topic %s: %v", topic, err)

--- a/examples/7-redis/consumer.go
+++ b/examples/7-redis/consumer.go
@@ -25,6 +25,7 @@ func Consume(pub Publisher, brokers []string, group string, stream string, store
 	if err != nil {
 		log.Fatalf("Error creating topic manager: %v", err)
 	}
+	defer tm.Close()
 	err = tm.EnsureStreamExists(stream, 8)
 	if err != nil {
 		log.Printf("Error creating kafka topic %s: %v", stream, err)

--- a/examples/7-redis/consumer.go
+++ b/examples/7-redis/consumer.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log"
 
 	"github.com/lovoo/goka"
 	storage "github.com/lovoo/goka/storage/redis"
@@ -18,6 +19,16 @@ type Publisher interface {
 // Consume starts goka events consumer.
 func Consume(pub Publisher, brokers []string, group string, stream string, store string, namespace string) error {
 	codec := new(Codec)
+
+	tmc := goka.NewTopicManagerConfig()
+	tm, err := goka.NewTopicManager(brokers, goka.DefaultConfig(), tmc)
+	if err != nil {
+		log.Fatalf("Error creating topic manager: %v", err)
+	}
+	err = tm.EnsureStreamExists(stream, 8)
+	if err != nil {
+		log.Printf("Error creating kafka topic %s: %v", stream, err)
+	}
 
 	input := goka.Input(goka.Stream(stream), codec, func(ctx goka.Context, msg interface{}) {
 		event, ok := msg.(*Event)

--- a/examples/8-monitoring/main.go
+++ b/examples/8-monitoring/main.go
@@ -297,6 +297,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("error creating topic manager: %v", err)
 	}
+	defer tmgr.Close()
 	tmgr.EnsureStreamExists(string(topic), 2)
 	tmgr.EnsureTableExists(string(goka.GroupTable(group)), 2)
 


### PR DESCRIPTION
Because of the changes in commit [2ff0aea](https://github.com/lovoo/goka/commit/2ff0aea4c3a5bd26a69fb05f39547087476a9d53#diff-1b67deb286bd0f23cb40b5e5e165d7d8a149460f30b0a82701e4aa17d3834b73 ) topics will not get automatically created, which breaks examples 2, 3, 5, 6, 7 and 8.

This is fixed in this PR by:
* creating topics explicitly before execution for application topics
* synchronize Goroutines so goka-internal topics will be created before they are referred to

Also applied a small fix in README.md of example 3: [e31d04d](https://github.com/lovoo/goka/commit/e31d04ddf8261cc00f7e455e2b78f38e68527e24)