### PR TITLE
Adds HSCAN key/value support to storage.redisIterator

### DIFF
--- a/storage/redis/redis.go
+++ b/storage/redis/redis.go
@@ -136,10 +136,11 @@ func (s *redisStorage) Close() error {
 // redisIterator is populated with the results of an HSCAN call for the table's key (https://redis.io/commands/scan/).
 // This result is a single-dimension array that contains [n] == key, [n+1] == value.
 type redisIterator struct {
-	current uint64
-	keys    []string
-	client  *redis.Client
-	hash    string
+	current     uint64
+	keys        []string
+	client      *redis.Client
+	hash        string
+	initialized bool
 }
 
 func (i *redisIterator) exhausted() bool {
@@ -157,7 +158,11 @@ func (i *redisIterator) ignoreOffsetKey() bool {
 }
 
 func (i *redisIterator) Next() bool {
-	i.current = i.current + 2
+	if !i.initialized {
+		i.initialized = true
+	} else {
+		i.current = i.current + 2
+	}
 	return i.ignoreOffsetKey()
 }
 

--- a/storage/redis/redis_test.go
+++ b/storage/redis/redis_test.go
@@ -42,12 +42,14 @@ func Test_redisIterator(t *testing.T) {
 }
 
 func assertRedisIterator(t *testing.T, it *redisIterator) {
+	// the iterator contract implies we must call `Next()` first
+	it.Next()
 	assertRedisIteratorKey(t, it, "key1", "val1")
-	it.Next()
 
+	it.Next()
 	assertRedisIteratorKey(t, it, "key2", "val2")
+	
 	it.Next()
-
 	if !it.exhausted() {
 		t.Fatalf("Expected iterator to be exhausted in %s", string(debug.Stack()))
 	}

--- a/storage/redis/redis_test.go
+++ b/storage/redis/redis_test.go
@@ -1,0 +1,70 @@
+package redis
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func Test_redisIterator(t *testing.T) {
+	assertRedisIterator(t, &redisIterator{
+		current: 0,
+		keys: []string{
+			"key1",
+			"val1",
+			offsetKey,
+			"123",
+			"key2",
+			"val2",
+		},
+	})
+	assertRedisIterator(t, &redisIterator{
+		current: 0,
+		keys: []string{
+			offsetKey,
+			"123",
+			"key1",
+			"val1",
+			"key2",
+			"val2",
+		},
+	})
+	assertRedisIterator(t, &redisIterator{
+		current: 0,
+		keys: []string{
+			"key1",
+			"val1",
+			"key2",
+			"val2",
+			offsetKey,
+			"123",
+		},
+	})
+}
+
+func assertRedisIterator(t *testing.T, it *redisIterator) {
+	assertRedisIteratorKey(t, it, "key1", "val1")
+	it.Next()
+
+	assertRedisIteratorKey(t, it, "key2", "val2")
+	it.Next()
+
+	if !it.exhausted() {
+		t.Fatalf("Expected iterator to be exhausted in %s", string(debug.Stack()))
+	}
+}
+
+func assertRedisIteratorKey(t *testing.T, it *redisIterator, expectedKey string, expectedValue string) {
+	if it.exhausted() {
+		t.Fatalf("Did not expect iterator to be exhausted in %s", string(debug.Stack()))
+	}
+
+	actualKey := string(it.Key())
+	if actualKey != expectedKey {
+		t.Fatalf("Expected iterator key to be '%s', but was '%s' in %s", expectedKey, actualKey, string(debug.Stack()))
+	}
+
+	actualValue, _ := it.Value()
+	if string(actualValue) != expectedValue {
+		t.Fatalf("Expected iterator value to be '%s', but was '%s' in %s", expectedValue, actualValue, string(debug.Stack()))
+	}
+}


### PR DESCRIPTION
The HSCAN result gives us a 1-dimensional array with [n] == key, [n+1] == value so we take advantage of that in the redisIterator.

FWIW We've been running this in production for the past 2 weeks with no issues. Before this change we were chugging through unexpected keys in `VisitAll`. Most of them were the *values* being passed as *keys*, a handful were the offset values (one per partition). After this change, we are only `Visit`ing the expected keys.