### PR TITLE
Adds `Signal.WaitForStateMinWithCleanup` to avoid leaking waiters

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -800,7 +800,8 @@ func (g *Processor) ConsumeClaim(session sarama.ConsumerGroupSession, claim sara
 	}
 
 	messages := claim.Messages()
-	stopping := part.stopping()
+	stopping, doneWaitingForStop := part.stopping()
+	defer doneWaitingForStop()
 
 	for {
 		select {


### PR DESCRIPTION
If `Signal.WaitForState*` is called multiple times for a state like "stopping", the waiters will remain in the signal's queue forever and their channel will remain open. This has happened in my case while calling `PartitionProcessor.VisitValues` multiple times. This was causing `Signal.waiters` to grow indefinitely and cause a memory leak. 
This change adds a cleanup function to allow a caller to remove itself from the `Signal.waiters` list if it no longer cares about waiting for the given state.

fixes https://github.com/lovoo/goka/issues/398