### PR TITLE
Fix clone functions of InputStats and OutputStats to prevent data race condition

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -93,11 +93,13 @@ func newOutputStats() *OutputStats {
 }
 
 func (is *InputStats) clone() *InputStats {
-	return &(*is)
+	var clone = *is
+	return &clone
 }
 
 func (os *OutputStats) clone() *OutputStats {
-	return &(*os)
+	var clone = *os
+	return &clone
 }
 
 type inputStatsMap map[string]*InputStats


### PR DESCRIPTION
`&(*x)` doesn't clone the data (that pattern has used for the `clone()` function for `goka.InputStats` and `goka.OutputStats`) into a new instance because it is simplified to `x`. (This can be detected by [staticcheck SA4001](https://staticcheck.io/docs/checks#SA4001)) So, it has made data race condition when a cloned stats is used. We have observed this in Goka web monitor and other places where it is using `View.Stats`.

This can be reproduced with a goka web monitor enabled application by turning on the Go race detector `-race`.

<img width="1146" alt="Screen Shot 2022-11-26 at 12 51 42 AM" src="https://user-images.githubusercontent.com/101293/204080638-af884805-95cb-470f-b808-91159d29a544.png">

<img width="1053" alt="Screen Shot 2022-11-26 at 12 50 59 AM" src="https://user-images.githubusercontent.com/101293/204080640-2b2ba28d-6344-4162-be83-6fceb8b3b8ac.png">
