### PR TITLE
Fix race condition

### DIFF
--- a/simple_backoff.go
+++ b/simple_backoff.go
@@ -1,6 +1,9 @@
 package goka
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // NewSimpleBackoff returns a simple backoff waiting the
 // specified duration longer each iteration until reset.
@@ -12,16 +15,22 @@ func NewSimpleBackoff(step time.Duration, max time.Duration) Backoff {
 }
 
 type simpleBackoff struct {
+	sync.Mutex
+
 	current time.Duration
 	step    time.Duration
 	max     time.Duration
 }
 
 func (b *simpleBackoff) Reset() {
+	b.Lock()
+	defer b.Unlock()
 	b.current = time.Duration(0)
 }
 
 func (b *simpleBackoff) Duration() time.Duration {
+	b.Lock()
+	defer b.Unlock()
 	value := b.current
 
 	if (b.current + b.step) <= b.max {


### PR DESCRIPTION
Fixes a race condition in the partition table backoff / retry where multiple go routines try to access data due to being used in time.AfterFunc callbacks.