### PR TITLE
bugfix stuck fetchstats on slow views/processors

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -327,8 +327,7 @@ func TestContext_Set(t *testing.T) {
 			st: &storageProxy{
 				Storage: st,
 			},
-			stats:       newTableStats(),
-			updateStats: make(chan func(), 10),
+			stats: newTableStats(),
 		}
 	)
 	st.EXPECT().Set(key, []byte(value)).Return(nil)
@@ -376,9 +375,8 @@ func TestContext_GetSetStateful(t *testing.T) {
 			st: &storageProxy{
 				Storage: st,
 			},
-			state:       newPartitionTableState().SetState(State(PartitionRunning)),
-			stats:       newTableStats(),
-			updateStats: make(chan func(), 10),
+			state: newPartitionTableState().SetState(State(PartitionRunning)),
+			stats: newTableStats(),
 		}
 	)
 

--- a/partition_table_test.go
+++ b/partition_table_test.go
@@ -631,6 +631,7 @@ func TestPT_loadMessages(t *testing.T) {
 			topic                  = "some-topic"
 			partition        int32
 			consumer         = defaultSaramaAutoConsumerMock(t)
+			ctx              = context.Background()
 		)
 		pt, bm, ctrl := defaultPT(
 			t,
@@ -656,7 +657,8 @@ func TestPT_loadMessages(t *testing.T) {
 					return
 				default:
 				}
-				if pt.stats.Stalled {
+
+				if pt.fetchStats(ctx).Stalled {
 					return
 				}
 			}

--- a/stats.go
+++ b/stats.go
@@ -28,7 +28,7 @@ const (
 )
 
 const (
-	statsHwmUpdateInterval = 5 * time.Second
+	statsHwmUpdateInterval = 60 * time.Second
 	fetchStatsTimeout      = 10 * time.Second
 )
 
@@ -93,20 +93,22 @@ func newOutputStats() *OutputStats {
 }
 
 func (is *InputStats) clone() *InputStats {
-	var clone = *is
+	clone := *is
 	return &clone
 }
 
 func (os *OutputStats) clone() *OutputStats {
-	var clone = *os
+	clone := *os
 	return &clone
 }
 
-type inputStatsMap map[string]*InputStats
-type outputStatsMap map[string]*OutputStats
+type (
+	inputStatsMap  map[string]*InputStats
+	outputStatsMap map[string]*OutputStats
+)
 
 func (isp inputStatsMap) clone() map[string]*InputStats {
-	var c = map[string]*InputStats{}
+	c := map[string]*InputStats{}
 	if isp == nil {
 		return c
 	}
@@ -117,7 +119,7 @@ func (isp inputStatsMap) clone() map[string]*InputStats {
 }
 
 func (osp outputStatsMap) clone() map[string]*OutputStats {
-	var c = map[string]*OutputStats{}
+	c := map[string]*OutputStats{}
 	if osp == nil {
 		return c
 	}
@@ -132,7 +134,7 @@ func newRecoveryStats() *RecoveryStats {
 }
 
 func (rs *RecoveryStats) clone() *RecoveryStats {
-	var rsCopy = *rs
+	rsCopy := *rs
 	return &rsCopy
 }
 

--- a/view.go
+++ b/view.go
@@ -149,7 +149,6 @@ func (v *View) createPartitions(brokers []string) (rerr error) {
 }
 
 func (v *View) runStateMerger(ctx context.Context) {
-
 	var (
 		states = make(map[int]PartitionStatus)
 		m      sync.Mutex
@@ -164,14 +163,14 @@ func (v *View) runStateMerger(ctx context.Context) {
 		defer m.Unlock()
 		states[idx] = PartitionStatus(state)
 
-		var lowestState = PartitionStatus(-1)
+		lowestState := PartitionStatus(-1)
 
 		for _, partitionState := range states {
 			if lowestState == -1 || partitionState < lowestState {
 				lowestState = partitionState
 			}
 		}
-		var newState = ViewState(-1)
+		newState := ViewState(-1)
 		switch lowestState {
 		case PartitionStopped:
 			newState = ViewStateIdle
@@ -249,7 +248,6 @@ func (v *View) Run(ctx context.Context) (rerr error) {
 
 	for _, partition := range v.partitions {
 		partition := partition
-		go partition.RunStatsLoop(ctx)
 		recoverErrg.Go(func() error {
 			return partition.SetupAndRecover(recoverCtx, v.opts.autoreconnect)
 		})
@@ -333,7 +331,6 @@ func (v *View) Topic() string {
 // Get can be called by multiple goroutines concurrently.
 // Get can only be called after Recovered returns true.
 func (v *View) Get(key string) (interface{}, error) {
-
 	if v.state.IsState(State(ViewStateIdle)) || v.state.IsState(State(ViewStateInitializing)) {
 		return nil, fmt.Errorf("View is either not running, not correctly initialized or stopped again. It's not safe to retrieve values")
 	}


### PR DESCRIPTION
This PR removes the channel-based handling of setting/getting stats from partition processors and partition tables.
Due to a bug, the channel based solution could get stuck on high-traffic processors/views and never return any stats anymore.