### PR TITLE
Correct README's example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ func runProcessor() {
 }
 
 func main() {
-	go runEmitter() // emits one message and stops
+	go runEmitter() // emits one message every second forever
 	runProcessor()  // press ctrl-c to stop
 }
 


### PR DESCRIPTION
For the usage example in the README it's mentioned that the emitter runs once and stops while it actually runs forever and keeps emitting a message every second.

We can just correct that single statement.