### PR TITLE
Fix/add links in READMEs

### DIFF
--- a/examples/4-tests/README.md
+++ b/examples/4-tests/README.md
@@ -2,5 +2,4 @@
 
 This Example demonstrates the testing capabilities of the tester package.
 
-Check the source file to get the examples
-https://github.com/lovoo/goka/blob/master/examples/4-tests/example_test.go
+Check the [source file](https://github.com/lovoo/goka/blob/master/examples/4-tests/example_test.go) to get the examples.

--- a/examples/8-monitoring/README.md
+++ b/examples/8-monitoring/README.md
@@ -33,7 +33,7 @@ go proc.Run(context.Background())
 http.ListenAndServe(":9095", root)
 ```
 
-Opening the browser on [localhost:9095/monitor/]() will then show us a list of all attached processors
+Opening the browser on [localhost:9095/monitor/](http://localhost:9095/monitor/) will then show us a list of all attached processors
 and views and by selecting one of them we'll get statistics of the processor, similar like this
 
 ![Processor View](images/processor-view.png?raw=true "processor view")
@@ -49,7 +49,7 @@ idxServer := index.NewServer("/", root)
 idxServer.AddComponent(monitorServer, "Monitor")
 ```
 
-So next time we open the page at [localhost:9095](), we'll get some nice links to the monitor.
+So next time we open the page at [localhost:9095](http://localhost:9095), we'll get some nice links to the monitor.
 
 ![Index](images/index.png?raw=true "index view")
 
@@ -73,7 +73,7 @@ Voila!
 
 ## Example
 
-The example in [main.go]() demonstrates the concepts and typical applications of the web interface by
+The example in [main.go](https://github.com/lovoo/goka/blob/master/examples/8-monitoring/main.go) demonstrates the concepts and typical applications of the web interface by
 creating an Emitter, multiple Processors and a web interface.
 
 Be sure to have Apache Kafka and Zookeeper running by starting it in the examples-folder.

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ This is a very simple toy application that demonstrates how to
 
 ### Clicks
 Similar to the first example, Emitter, Processor and View are demonstrated here.
-In Addition it shows how to
+In addition, it shows how to
 
 * access the View using a web endpoint
 * use a Codecs
@@ -39,7 +39,7 @@ The following examples show the combination of multiple processors, views, etc.
 
 By generating a random folder for storage, this example can be executed in parallel multiple times to get a feeling for the rebalancing that's happening under the hood.
 
-[Example]https://github.com/lovoo/goka/tree/master/examples/5-multiple/)
+[Example](https://github.com/lovoo/goka/tree/master/examples/5-multiple/)
 
 
 ###  Monitoring


### PR DESCRIPTION
This is just a casual PR fixing some links in READMEs. 

Additionally, I've found the following dead links in Project's Wiki:
- Under [Using Confluent Kafka client](https://github.com/lovoo/goka/wiki/Tips#using-confluent-kafka-client) section the [github.com/lovoo/goka/kafka/confluent](https://github.com/lovoo/goka/tree/master/kafka/confluent) link leads to 404. 
- Under [Add monitoring and statistics](https://github.com/lovoo/goka/wiki/Tips#add-monitoring-and-statistics) section the [example](https://github.com/lovoo/goka/tree/master/examples/monitoring) link leads to 404. It should probably be [example](https://github.com/lovoo/goka/tree/master/examples/8-monitoring)