### PR TITLE
Improve processor stopped state management

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -63,6 +63,7 @@ type Processor struct {
 
 	state *Signal
 
+	err    error
 	done   chan struct{}
 	cancel context.CancelFunc
 }
@@ -263,7 +264,8 @@ func (g *Processor) Run(ctx context.Context) (rerr error) {
 	// collect all errors before leaving
 	var errs *multierror.Error
 	defer func() {
-		rerr = multierror.Append(errs, rerr).ErrorOrNil()
+		g.err = multierror.Append(errs, rerr).ErrorOrNil()
+		rerr = g.err
 	}()
 
 	var err error
@@ -932,6 +934,11 @@ func (g *Processor) Stop() {
 // Done returns a channel that is closed when the processor is stopped.
 func (g *Processor) Done() <-chan struct{} {
 	return g.done
+}
+
+// Error returns the error that caused the processor to stop.
+func (g *Processor) Error() error {
+	return g.err
 }
 
 // VisitAllWithStats visits all keys in parallel by passing the visit request

--- a/processor.go
+++ b/processor.go
@@ -63,6 +63,7 @@ type Processor struct {
 
 	state *Signal
 
+	errMux sync.Mutex
 	err    error
 	done   chan struct{}
 	cancel context.CancelFunc
@@ -264,6 +265,8 @@ func (g *Processor) Run(ctx context.Context) (rerr error) {
 	// collect all errors before leaving
 	var errs *multierror.Error
 	defer func() {
+		g.errMux.Lock()
+		defer g.errMux.Unlock()
 		g.err = multierror.Append(errs, rerr).ErrorOrNil()
 		rerr = g.err
 	}()
@@ -938,6 +941,8 @@ func (g *Processor) Done() <-chan struct{} {
 
 // Error returns the error that caused the processor to stop.
 func (g *Processor) Error() error {
+	g.errMux.Lock()
+	defer g.errMux.Unlock()
 	return g.err
 }
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -351,7 +351,7 @@ func TestProcessor_Run(t *testing.T) {
 		consBuilder, _ := createTestConsumerBuilder(t)
 
 		graph := DefineGroup("test",
-			// not really used, we're failing anyway
+			// not really used, we're stopping before the processor before producing
 			Input("input", new(codec.Int64), accumulate),
 		)
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -315,6 +315,7 @@ func TestProcessor_Run(t *testing.T) {
 		// and waiting for them to be delivered
 		<-done
 		require.True(t, strings.Contains(procErr.Error(), "setup-error"))
+		require.True(t, strings.Contains(newProc.Error().Error(), "setup-error"))
 	})
 }
 
@@ -410,12 +411,9 @@ func TestProcessor_Stop(t *testing.T) {
 			bm.createProcessorOptions(consBuilder, groupBuilder)...,
 		)
 		require.NoError(t, err)
-		var (
-			procErr error
-		)
 
 		go func() {
-			procErr = newProc.Run(ctx)
+			newProc.Run(ctx)
 		}()
 
 		newProc.WaitForReady()
@@ -425,7 +423,7 @@ func TestProcessor_Stop(t *testing.T) {
 
 		select {
 		case <-newProc.Done():
-			require.NoError(t, procErr)
+			require.NoError(t, newProc.Error())
 		case <-time.After(10 * time.Second):
 			t.Errorf("processor did not shut down as expected")
 		}

--- a/processor_test.go
+++ b/processor_test.go
@@ -385,9 +385,7 @@ func TestProcessor_Stop(t *testing.T) {
 			t.Errorf("processor did not shut down as expected")
 		}
 	})
-}
 
-func TestProcessor_Done(t *testing.T) {
 	t.Run("done-closes", func(t *testing.T) {
 		ctrl, bm := createMockBuilder(t)
 		defer ctrl.Finish()


### PR DESCRIPTION
* Introduce a new `Stopped` state for processors. Since a processor cannot be restarted after it has been run, this state better indicates that the processor has reached its final state.
* Expose a new `Done()` method on the processor to allow waiting on a processor to complete. This avoids the need to apply additional "done" channels on top of the processor when processors in go routines.