### PR TITLE
fix a deadlock in the consumer mock

### DIFF
--- a/mockautoconsumers.go
+++ b/mockautoconsumers.go
@@ -249,7 +249,9 @@ func (pc *MockAutoPartitionConsumer) Close() error {
 			pc.t.Errorf("Expected the messages channel for %s/%d to be drained on close, but found %d messages.", pc.topic, pc.partition, len(pc.messages))
 		}
 
-		pc.AsyncClose()
+		close(pc.messages)
+		close(pc.errors)
+		pc.consumed = false
 
 		var (
 			closeErr error


### PR DESCRIPTION
Found a deadlock in the `MockAutoPartitionConsumer`. The `Close()` function does all of its work from within a `sync.Once`. However, the `AsyncClose()` function utilizes the same `sync.Once` to do its work. `Close()` calls `AsyncClose()` from within the once invocation and results in a deadlock as the mutex is being held by the outer `Close()`.

This change inlines the operations `AsyncClose()` would've performed into the main body of `Close()`, removing the possibility for deadlock.