### PR TITLE
Add message timestamp to view update context

### DIFF
--- a/options.go
+++ b/options.go
@@ -28,6 +28,9 @@ type UpdateContext interface {
 	// It is recommended to lazily evaluate the headers to reduce overhead per message
 	// when headers are not used.
 	Headers() Headers
+
+	// Timestamp returns the timestamp of the input message.
+	Timestamp() time.Time
 }
 
 // UpdateCallback is invoked upon arrival of a message for a table partition.
@@ -95,6 +98,7 @@ type DefaultUpdateContext struct {
 	partition int32
 	offset    int64
 	headers   []*sarama.RecordHeader
+	timestamp time.Time
 }
 
 // Topic returns the topic of input message.
@@ -115,6 +119,11 @@ func (ctx DefaultUpdateContext) Offset() int64 {
 // Headers returns the headers of the input message.
 func (ctx DefaultUpdateContext) Headers() Headers {
 	return HeadersFromSarama(ctx.headers)
+}
+
+// Timestamp returns the timestamp of the input message.
+func (ctx DefaultUpdateContext) Timestamp() time.Time {
+	return ctx.timestamp
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/partition_table.go
+++ b/partition_table.go
@@ -462,7 +462,7 @@ func (p *PartitionTable) loadMessages(ctx context.Context, cons sarama.Partition
 			}
 
 			lastMessage = time.Now()
-			if err := p.storeEvent(string(msg.Key), msg.Value, msg.Offset, msg.Headers); err != nil {
+			if err := p.storeEvent(string(msg.Key), msg.Value, msg.Offset, msg.Headers, msg.Timestamp); err != nil {
 				return fmt.Errorf("load: error updating storage: %v", err)
 			}
 
@@ -534,12 +534,13 @@ func (p *PartitionTable) TrackMessageWrite(ctx context.Context, length int) {
 	})
 }
 
-func (p *PartitionTable) storeEvent(key string, value []byte, offset int64, headers []*sarama.RecordHeader) error {
+func (p *PartitionTable) storeEvent(key string, value []byte, offset int64, headers []*sarama.RecordHeader, timestamp time.Time) error {
 	err := p.st.Update(&DefaultUpdateContext{
 		topic:     p.st.topic,
 		partition: p.st.partition,
 		offset:    offset,
 		headers:   headers,
+		timestamp: timestamp,
 	}, key, value)
 	if err != nil {
 		return fmt.Errorf("Error from the update callback while recovering from the log: %v", err)


### PR DESCRIPTION
This PR adds the record timestamp to view's [UpdateContext](https://github.com/lovoo/goka/blob/85b1720e021673fd117d7a4aa507db488a148cf2/options.go#L16-L31).

Having access to record's timestamp helps us greatly with measuring the lag when the compacted topic is replicated in different regions.

I ran this version locally and it's working well. Please let me know if I missed something. Thank you!