### PR TITLE
improve processor stability

### DIFF
--- a/options.go
+++ b/options.go
@@ -363,7 +363,7 @@ func (opt *poptions) applyOptions(gg *GroupGraph, opts ...ProcessorOption) error
 	}
 
 	if globalConfig.Producer.RequiredAcks == sarama.NoResponse {
-		return fmt.Errorf("Processors do not work with `Config.Producer.RequiredAcks==sarama.NoResponse`, as it uses the response's offset to store the value")
+		return fmt.Errorf("processors do not work with `Config.Producer.RequiredAcks==sarama.NoResponse`, as it uses the response's offset to store the value")
 	}
 
 	if opt.builders.producer == nil {

--- a/processor.go
+++ b/processor.go
@@ -421,11 +421,11 @@ func (g *Processor) handleSessionErrors(ctx, sessionCtx context.Context, session
 			)
 
 			if errors.As(err, &errProc) {
-				g.log.Debugf("error processing message (non-transient), shutting down processor: %v", err)
+				g.log.Printf("error processing message (non-transient), shutting down processor: %v", err)
 				sessionCtxCancel()
 			}
 			if errors.As(err, &errSetup) {
-				g.log.Debugf("setup error (non-transient), shutting down processor: %v", err)
+				g.log.Printf("setup error (non-transient), shutting down processor: %v", err)
 				sessionCtxCancel()
 			}
 		}

--- a/systemtest/proc_disconnect_test.go
+++ b/systemtest/proc_disconnect_test.go
@@ -18,6 +18,7 @@ func TestProcessorShutdown_KafkaDisconnect(t *testing.T) {
 	brokers := initSystemTest(t)
 	var (
 		topic = goka.Stream(fmt.Sprintf("goka_systemtest_proc_shutdown_disconnect-%d", time.Now().Unix()))
+		join  = goka.Stream(fmt.Sprintf("goka_systemtest_proc_shutdown_disconnect-%d-join", time.Now().Unix()))
 		group = goka.Group(topic)
 	)
 
@@ -29,6 +30,7 @@ func TestProcessorShutdown_KafkaDisconnect(t *testing.T) {
 	tmgr, err := goka.DefaultTopicManagerBuilder(brokers)
 	require.NoError(t, err)
 	require.NoError(t, tmgr.EnsureStreamExists(string(topic), 10))
+	require.NoError(t, tmgr.EnsureTableExists(string(join), 10))
 
 	// emit values
 	errg.Go(func() error {
@@ -69,6 +71,7 @@ func TestProcessorShutdown_KafkaDisconnect(t *testing.T) {
 					ctx.SetValue(msg)
 				}
 			}),
+			goka.Join(goka.Table(join), new(codec.String)),
 			goka.Persist(new(codec.Int64)),
 		),
 		goka.WithConsumerGroupBuilder(goka.ConsumerGroupBuilderWithConfig(cfg)),

--- a/systemtest/processor_test.go
+++ b/systemtest/processor_test.go
@@ -305,6 +305,7 @@ func TestRebalance(t *testing.T) {
 	var (
 		group              = goka.Group(fmt.Sprintf("goka-systemtest-rebalance-%d", time.Now().Unix()))
 		inputStream string = string(group) + "-input"
+		joinTable   string = string(group) + "-join"
 		basepath           = "/tmp/goka-rebalance-test"
 	)
 
@@ -318,6 +319,9 @@ func TestRebalance(t *testing.T) {
 	require.NoError(t, err)
 
 	err = tm.EnsureStreamExists(inputStream, 20)
+	require.NoError(t, err)
+
+	err = tm.EnsureTableExists(joinTable, 20)
 	require.NoError(t, err)
 
 	em, err := goka.NewEmitter(brokers, goka.Stream(inputStream), new(codec.String))
@@ -338,6 +342,7 @@ func TestRebalance(t *testing.T) {
 			goka.DefineGroup(
 				group,
 				goka.Input(goka.Stream(inputStream), new(codec.String), func(ctx goka.Context, msg interface{}) { ctx.SetValue(msg) }),
+				goka.Join(goka.Table(joinTable), new(codec.String)),
 				goka.Persist(new(codec.String)),
 			),
 			goka.WithRecoverAhead(),

--- a/topic_manager.go
+++ b/topic_manager.go
@@ -89,7 +89,7 @@ func checkBroker(broker Broker, config *sarama.Config) error {
 	}
 
 	err := broker.Open(config)
-	if err != nil {
+	if err != nil && !errors.Is(err, sarama.ErrAlreadyConnected) {
 		return fmt.Errorf("error opening broker connection: %v", err)
 	}
 	connected, err := broker.Connected()


### PR DESCRIPTION
## What this PR tries to improve
Stability of processors in the face of restarting/unstable kafka processors.

## Background
We're facing the issue that our kafka-cluster restarts or rebalances from time to time, which makes all processors restart. Since the processors will rebalance, this PR uses reconnecting views to be used for the join/lookup tables. 
