### PR TITLE
fix the issue with offsetOutOfRange

### DIFF
--- a/partition_table.go
+++ b/partition_table.go
@@ -2,6 +2,7 @@ package goka
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -330,7 +331,7 @@ func (p *PartitionTable) load(ctx context.Context, stopAfterCatchup bool) (rerr 
 	defer p.log.Debugf("... Loading done")
 
 	partConsumer, err = p.consumer.ConsumePartition(p.topic, p.partition, loadOffset)
-	if err == sarama.ErrOffsetOutOfRange {
+	if errors.Is(err, sarama.ErrOffsetOutOfRange) {
 		p.log.Printf("Offset %d out of range for topic %s, partition %d. Falling back to oldest offset.", loadOffset, p.topic, p.partition)
 
 		partConsumer, err = p.consumer.ConsumePartition(p.topic, p.partition, sarama.OffsetOldest)
@@ -353,6 +354,22 @@ func (p *PartitionTable) load(ctx context.Context, stopAfterCatchup bool) (rerr 
 
 	// load messages and stop when you're at HWM
 	loadErr := p.loadMessages(ctx, partConsumer, hwm, stopAfterCatchup)
+	if loadErr != nil && errors.Is(loadErr, sarama.ErrOffsetOutOfRange) {
+		p.log.Printf("Offset out of range during consumption for topic %s, partition %d. Restarting consumer from oldest offset.", p.topic, p.partition)
+
+		// close current consumer before creating a new one
+		partConsumer.AsyncClose()
+		if drainErr := p.drainConsumer(partConsumer); drainErr != nil {
+			p.log.Printf("Error draining consumer for topic %s, partition %d: %v", p.topic, p.partition, drainErr)
+		}
+
+		partConsumer, err = p.consumer.ConsumePartition(p.topic, p.partition, sarama.OffsetOldest)
+		if err != nil {
+			return fmt.Errorf("Error creating fallback partition consumer for topic %s, partition %d: %v", p.topic, p.partition, err)
+		}
+
+		loadErr = p.loadMessages(ctx, partConsumer, hwm, stopAfterCatchup)
+	}
 
 	if loadErr != nil {
 		return loadErr

--- a/partition_table.go
+++ b/partition_table.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/IBM/sarama"
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/lovoo/goka/multierr"
 	"github.com/lovoo/goka/storage"
 )
@@ -329,8 +330,13 @@ func (p *PartitionTable) load(ctx context.Context, stopAfterCatchup bool) (rerr 
 	defer p.log.Debugf("... Loading done")
 
 	partConsumer, err = p.consumer.ConsumePartition(p.topic, p.partition, loadOffset)
-	if err != nil {
-		return fmt.Errorf("Error creating partition consumer for topic %s, partition %d, offset %d: %v", p.topic, p.partition, storedOffset, err)
+	if err == sarama.ErrOffsetOutOfRange {
+		p.log.Printf("Offset %d out of range for topic %s, partition %d. Falling back to oldest offset.", loadOffset, p.topic, p.partition)
+
+		partConsumer, err = p.consumer.ConsumePartition(p.topic, p.partition, sarama.OffsetOldest)
+		if err != nil {
+			return fmt.Errorf("Error creating partition consumer for topic %s, partition %d, offset %d: %v", p.topic, p.partition, storedOffset, err)
+		}
 	}
 
 	// close the consumer


### PR DESCRIPTION
 **Summary**
Handle ErrOffsetOutOfRange in goka's partition table recovery by falling back to sarama.OffsetOldest instead of crashing the processor
                                                                                                                                                                                                                                                                                       
**Problem**
```                                                                                                                                                
  Production error:                                                                                                                                                                                                                                                        
  error consuming %TOPIC%: kafka server: The requested offset is outside   
  the range of offsets maintained by the server for the given topic/partition         
```
Goka's findOffsetToLoad() adjusts offsets below the broker's oldest, but a race condition exists: the oldest offset can shift between the metadata fetch and the actual ConsumePartition call (e.g. due to log compaction or retention cleanup), causing ErrOffsetOutOfRange.
                                                                                                                                                                                                                                                                                       
**Fix**                                                                                                                                                                                                                                                       When ConsumePartition returns ErrOffsetOutOfRange, retry with sarama.OffsetOldest (lets the broker resolve the actual earliest offset) instead of failing the partition setup.