### PR TITLE
feat: add Sarama hooks for Datadog and OpenTelemetry tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This README provides a brief, high level overview of the ideas behind Goka.
 
 Package API documentation is available at [GoDoc] and the [Wiki](https://github.com/lovoo/goka/wiki/Tips#configuring-log-compaction-for-table-topics) provides several tips for configuring, extending, and deploying Goka applications.
 
+For distributed tracing with Sarama instrumentation libraries, see [docs/tracing.md](docs/tracing.md).
+
 ## Installation
 
 You can install Goka by running the following command:

--- a/builders.go
+++ b/builders.go
@@ -19,18 +19,10 @@ func DefaultProducerBuilder(brokers []string, clientID string, hasher func() has
 }
 
 // ProducerBuilderWithConfig creates a Kafka producer using the Sarama library.
-func ProducerBuilderWithConfig(config *sarama.Config) ProducerBuilder {
-	return ProducerBuilderWithAsyncProducerWrapper(config, nil)
-}
+func ProducerBuilderWithConfig(config *sarama.Config, opts ...ProducerBuilderOption) ProducerBuilder {
+	pbOpts := new(producerBuilderOptions)
+	pbOpts.applyOptions(opts...)
 
-// AsyncProducerWrapper wraps a newly created sarama.AsyncProducer before goka
-// attaches its Promise completion loop.
-type AsyncProducerWrapper func(producer sarama.AsyncProducer, config *sarama.Config) sarama.AsyncProducer
-
-// ProducerBuilderWithAsyncProducerWrapper creates a producer builder that
-// constructs a sarama.AsyncProducer, applies wrap, then returns a goka Producer
-// via NewProducerFromAsyncProducer. A nil wrap is equivalent to ProducerBuilderWithConfig.
-func ProducerBuilderWithAsyncProducerWrapper(config *sarama.Config, wrap AsyncProducerWrapper) ProducerBuilder {
 	return func(brokers []string, clientID string, hasher func() hash.Hash32) (Producer, error) {
 		config.ClientID = clientID
 		config.Producer.Partitioner = sarama.NewCustomHashPartitioner(hasher)
@@ -38,10 +30,35 @@ func ProducerBuilderWithAsyncProducerWrapper(config *sarama.Config, wrap AsyncPr
 		if err != nil {
 			return nil, fmt.Errorf("failed to start Sarama producer: %w", err)
 		}
-		if wrap != nil {
-			aprod = wrap(aprod, config)
+		if pbOpts.asyncProducerWrapper != nil {
+			aprod = pbOpts.asyncProducerWrapper(config, aprod)
 		}
 		return NewProducerFromAsyncProducer(aprod), nil
+	}
+}
+
+// ProducerBuilderOption configures ProducerBuilderWithConfig.
+type ProducerBuilderOption func(*producerBuilderOptions)
+
+type producerBuilderOptions struct {
+	asyncProducerWrapper AsyncProducerWrapper
+}
+
+func (o *producerBuilderOptions) applyOptions(opts ...ProducerBuilderOption) {
+	for _, opt := range opts {
+		opt(o)
+	}
+}
+
+// AsyncProducerWrapper wraps a newly created sarama.AsyncProducer before goka
+// attaches its Promise completion loop.
+type AsyncProducerWrapper func(config *sarama.Config, producer sarama.AsyncProducer) sarama.AsyncProducer
+
+// WithAsyncProducerWrapper applies wrap to the sarama.AsyncProducer before
+// goka attaches its Promise completion loop.
+func WithAsyncProducerWrapper(wrap AsyncProducerWrapper) ProducerBuilderOption {
+	return func(o *producerBuilderOptions) {
+		o.asyncProducerWrapper = wrap
 	}
 }
 

--- a/builders.go
+++ b/builders.go
@@ -1,6 +1,7 @@
 package goka
 
 import (
+	"fmt"
 	"hash"
 
 	"github.com/IBM/sarama"
@@ -17,12 +18,30 @@ func DefaultProducerBuilder(brokers []string, clientID string, hasher func() has
 	return NewProducer(brokers, &config)
 }
 
-// ProducerBuilderWithConfig creates a Kafka consumer using the Sarama library.
+// ProducerBuilderWithConfig creates a Kafka producer using the Sarama library.
 func ProducerBuilderWithConfig(config *sarama.Config) ProducerBuilder {
+	return ProducerBuilderWithAsyncProducerWrapper(config, nil)
+}
+
+// AsyncProducerWrapper wraps a newly created sarama.AsyncProducer before goka
+// attaches its Promise completion loop.
+type AsyncProducerWrapper func(producer sarama.AsyncProducer, config *sarama.Config) sarama.AsyncProducer
+
+// ProducerBuilderWithAsyncProducerWrapper creates a producer builder that
+// constructs a sarama.AsyncProducer, applies wrap, then returns a goka Producer
+// via NewProducerFromAsyncProducer. A nil wrap is equivalent to ProducerBuilderWithConfig.
+func ProducerBuilderWithAsyncProducerWrapper(config *sarama.Config, wrap AsyncProducerWrapper) ProducerBuilder {
 	return func(brokers []string, clientID string, hasher func() hash.Hash32) (Producer, error) {
 		config.ClientID = clientID
 		config.Producer.Partitioner = sarama.NewCustomHashPartitioner(hasher)
-		return NewProducer(brokers, config)
+		aprod, err := sarama.NewAsyncProducer(brokers, config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to start Sarama producer: %w", err)
+		}
+		if wrap != nil {
+			aprod = wrap(aprod, config)
+		}
+		return NewProducerFromAsyncProducer(aprod), nil
 	}
 }
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -16,7 +16,7 @@ cfg.Version = sarama.V0_11_0_0 // or newer
 | API | Role |
 |-----|------|
 | `WithConsumerGroupHandlerWrapper` | Wraps the processor's `sarama.ConsumerGroupHandler` before `ConsumerGroup.Consume`. Pass the result of `WrapConsumerGroupHandler` (or equivalent). |
-| `WithProducerBuilder` + `ProducerBuilderWithAsyncProducerWrapper` | Builds a `sarama.AsyncProducer`, applies your wrap function (e.g. `WrapAsyncProducer`), then hands it to goka. |
+| `WithProducerBuilder` + `ProducerBuilderWithConfig` | Builds a `sarama.AsyncProducer` and optionally wraps it (e.g. `WithAsyncProducerWrapper`), then hands it to goka. |
 | `NewProducerFromAsyncProducer` | Same idea for custom `ProducerBuilder` implementations: wrap first, then construct goka's `Producer`. |
 | `WithProcessMiddleware` | Wraps each `ProcessCallback` (input topics and visits). Use this to start and finish a span around handler logic. |
 | `TextMapHeaders` | Adapts `goka.Headers` for OpenTelemetry (`Get`/`Set`/`Keys`) and Datadog (`Set`/`ForeachKey`) text-map carriers. |
@@ -91,10 +91,8 @@ func Apply(group goka.Group, cfg *sarama.Config) []goka.ProcessorOption {
 				next(&tracingContext{Context: ctx, span: span}, msg)
 			}
 		}),
-		goka.WithProducerBuilder(goka.ProducerBuilderWithAsyncProducerWrapper(cfg,
-			func(p sarama.AsyncProducer, c *sarama.Config) sarama.AsyncProducer {
-				return saramatrace.WrapAsyncProducer(c, p)
-			},
+		goka.WithProducerBuilder(goka.ProducerBuilderWithConfig(cfg,
+			goka.WithAsyncProducerWrapper(saramatrace.WrapAsyncProducer),
 		)),
 	}
 }

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -15,7 +15,7 @@ cfg.Version = sarama.V0_11_0_0 // or newer
 
 | API | Role |
 |-----|------|
-| `WithConsumerGroupHandlerWrapper` | Wraps the processor's `sarama.ConsumerGroupHandler` before `ConsumerGroup.Consume`. Pass the result of `WrapConsumerGroupHandler` (or equivalent). |
+| `WithConsumerGroupHandlerWrapper` | Wraps the processor's `sarama.ConsumerGroupHandler` before `ConsumerGroup.Consume`, passing `group` and `clientID` (same as `ConsumerGroupBuilder`). |
 | `WithProducerBuilder` + `ProducerBuilderWithConfig` | Builds a `sarama.AsyncProducer` and optionally wraps it (e.g. `WithAsyncProducerWrapper`), then hands it to goka. |
 | `NewProducerFromAsyncProducer` | Same idea for custom `ProducerBuilder` implementations: wrap first, then construct goka's `Producer`. |
 | `WithProcessMiddleware` | Wraps each `ProcessCallback` (input topics and visits). Use this to start and finish a span around handler logic. |
@@ -68,10 +68,10 @@ import (
 
 // Apply returns processor options that wire Datadog's Sarama instrumentation
 // into a goka processor.
-func Apply(group goka.Group, cfg *sarama.Config) []goka.ProcessorOption {
+func Apply(cfg *sarama.Config) []goka.ProcessorOption {
 	return []goka.ProcessorOption{
-		goka.WithConsumerGroupHandlerWrapper(func(h sarama.ConsumerGroupHandler) sarama.ConsumerGroupHandler {
-			return saramatrace.WrapConsumerGroupHandler(h, saramatrace.WithGroupID(string(group)))
+		goka.WithConsumerGroupHandlerWrapper(func(h sarama.ConsumerGroupHandler, group, _ string) sarama.ConsumerGroupHandler {
+			return saramatrace.WrapConsumerGroupHandler(h, saramatrace.WithGroupID(group))
 		}),
 		goka.WithProcessMiddleware(func(next goka.ProcessCallback) goka.ProcessCallback {
 			return func(ctx goka.Context, msg interface{}) {
@@ -158,7 +158,7 @@ func (c *tracingContext) withProduceSpan(
 cfg := goka.DefaultConfig()
 cfg.Version = sarama.V0_11_0_0
 
-proc, err := goka.NewProcessor(brokers, graph, tracing.Apply(group, cfg)...)
+proc, err := goka.NewProcessor(brokers, graph, tracing.Apply(cfg)...)
 ```
 
 Example trace for a callback that updates state and emits downstream:

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,181 @@
+# Distributed tracing with Goka
+
+Goka does not bundle a tracing SDK. Applications instrument Kafka I/O with libraries such as [Datadog's IBM/sarama integration](https://github.com/DataDog/dd-trace-go/tree/main/contrib/IBM/sarama) or [otelsarama](https://github.com/dnwe/otelsarama), and use goka's extension points to attach those wrappers and to continue traces across message handling and emits.
+
+## Prerequisites
+
+Sarama tracing relies on Kafka message headers. Configure a broker version that supports them:
+
+```go
+cfg := goka.DefaultConfig()
+cfg.Version = sarama.V0_11_0_0 // or newer
+```
+
+## Extension points
+
+| API | Role |
+|-----|------|
+| `WithConsumerGroupHandlerWrapper` | Wraps the processor's `sarama.ConsumerGroupHandler` before `ConsumerGroup.Consume`. Pass the result of `WrapConsumerGroupHandler` (or equivalent). |
+| `WithProducerBuilder` + `ProducerBuilderWithAsyncProducerWrapper` | Builds a `sarama.AsyncProducer`, applies your wrap function (e.g. `WrapAsyncProducer`), then hands it to goka. |
+| `NewProducerFromAsyncProducer` | Same idea for custom `ProducerBuilder` implementations: wrap first, then construct goka's `Producer`. |
+| `WithProcessMiddleware` | Wraps each `ProcessCallback` (input topics and visits). Use this to start and finish a span around handler logic. |
+| `TextMapHeaders` | Adapts `goka.Headers` for OpenTelemetry (`Get`/`Set`/`Keys`) and Datadog (`Set`/`ForeachKey`) text-map carriers. |
+| `WithConsumerSaramaBuilder` / `WithViewConsumerSaramaBuilder` | Can wrap plain `sarama.Consumer` instances used for tables and views (e.g. `WrapConsumer`). |
+
+Incoming message headers are available on `Context.Headers()`. Outgoing headers can be set per emit with `WithCtxEmitHeaders`, or as processor defaults with `WithProducerDefaultHeaders`.
+
+## How messages flow (and what that means for spans)
+
+A processor does not run your callback on the Sarama claim goroutine. Roughly:
+
+1. The consumer group delivers a message on the claim's `Messages()` channel.
+2. Goka copies it onto an internal per-partition queue (`part.input`).
+3. Another goroutine later runs `ProcessCallback`, which may `Emit`, `Loopback`, `SetValue`, or `Delete`.
+
+Sarama instrumentation that wraps `ConsumerGroupHandler` typically creates a span when the message is read from the claim and finishes it based on claim delivery (for example, when the next message is handed off). That span therefore reflects **claim handoff**, not **callback execution**.
+
+To time the work your callback actually does—and to have an active span while emitting—start a span in `WithProcessMiddleware` that lasts for the duration of `next(...)`.
+
+Wrapping the plain table/view consumer is optional. Those clients are used heavily during recovery and catchup; wrapping them can create a large volume of receive spans that are unrelated to request handling.
+
+## Propagating context into emits
+
+`WrapAsyncProducer` (and equivalents) create produce spans from the trace context in the **outgoing** Kafka headers. Goka does not automatically copy the active process span into those headers.
+
+The usual approach is to return a custom `Context` from process middleware that:
+
+1. Exposes the process span via `Context()` (so application code and further instrumentation can find it).
+2. Overrides `Emit`, `Loopback`, `SetValue`, and/or `Delete` to inject the current span into headers (via `WithCtxEmitHeaders`) before delegating.
+
+You choose which operations to instrument. For example, you may inject on `Emit` and `Loopback` but skip `SetValue` if table-write produce spans are too noisy. If you override a method, you can also start a child span named for that operation (`goka.emit`, `goka.setvalue`, …). That is useful for distinguishing `SetValue` from `Delete`, which both write to the group table topic and otherwise look identical in producer-only instrumentation.
+
+Implement every method you care about; any produce path you leave on the embedded `Context` will not get your injection or child spans.
+
+## Example: Datadog
+
+```go
+package tracing
+
+import (
+	"context"
+
+	saramatrace "github.com/DataDog/dd-trace-go/contrib/IBM/sarama/v2"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/IBM/sarama"
+	"github.com/lovoo/goka"
+)
+
+// Apply returns processor options that wire Datadog's Sarama instrumentation
+// into a goka processor.
+func Apply(group goka.Group, cfg *sarama.Config) []goka.ProcessorOption {
+	return []goka.ProcessorOption{
+		goka.WithConsumerGroupHandlerWrapper(func(h sarama.ConsumerGroupHandler) sarama.ConsumerGroupHandler {
+			return saramatrace.WrapConsumerGroupHandler(h, saramatrace.WithGroupID(string(group)))
+		}),
+		goka.WithProcessMiddleware(func(next goka.ProcessCallback) goka.ProcessCallback {
+			return func(ctx goka.Context, msg interface{}) {
+				opts := []tracer.StartSpanOption{
+					tracer.ResourceName(string(ctx.Topic())),
+					tracer.SpanType(ext.SpanTypeMessageConsumer),
+					tracer.Tag(ext.MessagingSystem, ext.MessagingSystemKafka),
+					tracer.Tag(ext.MessagingKafkaPartition, ctx.Partition()),
+					tracer.Tag("offset", ctx.Offset()),
+					tracer.Measured(),
+				}
+				if parent, err := tracer.Extract(goka.TextMapHeaders(ctx.Headers())); err == nil {
+					opts = append(opts, tracer.ChildOf(parent))
+				}
+				span := tracer.StartSpan("goka.process", opts...)
+				defer span.Finish()
+				next(&tracingContext{Context: ctx, span: span}, msg)
+			}
+		}),
+		goka.WithProducerBuilder(goka.ProducerBuilderWithAsyncProducerWrapper(cfg,
+			func(p sarama.AsyncProducer, c *sarama.Config) sarama.AsyncProducer {
+				return saramatrace.WrapAsyncProducer(c, p)
+			},
+		)),
+	}
+}
+
+type tracingContext struct {
+	goka.Context
+	span *tracer.Span
+}
+
+func (c *tracingContext) Context() context.Context {
+	return tracer.ContextWithSpan(c.Context.Context(), c.span)
+}
+
+func (c *tracingContext) Emit(topic goka.Stream, key string, value interface{}, options ...goka.ContextOption) {
+	c.withProduceSpan("goka.emit", string(topic), func(opts []goka.ContextOption) {
+		c.Context.Emit(topic, key, value, opts...)
+	}, options...)
+}
+
+func (c *tracingContext) Loopback(key string, value interface{}, options ...goka.ContextOption) {
+	c.withProduceSpan("goka.loopback", "", func(opts []goka.ContextOption) {
+		c.Context.Loopback(key, value, opts...)
+	}, options...)
+}
+
+func (c *tracingContext) SetValue(value interface{}, options ...goka.ContextOption) {
+	c.withProduceSpan("goka.setvalue", "", func(opts []goka.ContextOption) {
+		c.Context.SetValue(value, opts...)
+	}, options...)
+}
+
+func (c *tracingContext) Delete(options ...goka.ContextOption) {
+	c.withProduceSpan("goka.delete", "", func(opts []goka.ContextOption) {
+		c.Context.Delete(opts...)
+	}, options...)
+}
+
+func (c *tracingContext) withProduceSpan(
+	op, topic string,
+	call func(opts []goka.ContextOption),
+	options ...goka.ContextOption,
+) {
+	opts := []tracer.StartSpanOption{
+		tracer.ResourceName(op),
+		tracer.SpanType(ext.SpanTypeMessageProducer),
+		tracer.Tag(ext.MessagingSystem, ext.MessagingSystemKafka),
+		tracer.Tag("goka.op", op),
+		tracer.ChildOf(c.span.Context()),
+	}
+	if topic != "" {
+		opts = append(opts, tracer.Tag(ext.MessagingDestinationName, topic))
+	}
+	span := tracer.StartSpan(op, opts...)
+	defer span.Finish()
+
+	h := goka.Headers{}
+	_ = tracer.Inject(span.Context(), goka.TextMapHeaders(h))
+	call(append(options, goka.WithCtxEmitHeaders(h)))
+}
+```
+
+```go
+cfg := goka.DefaultConfig()
+cfg.Version = sarama.V0_11_0_0
+
+proc, err := goka.NewProcessor(brokers, graph, tracing.Apply(group, cfg)...)
+```
+
+Example trace for a callback that updates state and emits downstream:
+
+```text
+kafka.consume                          // from WrapConsumerGroupHandler (claim-scoped)
+  └─ goka.process                      // from ProcessMiddleware (callback-scoped)
+       ├─ goka.setvalue
+       │    └─ Produce Topic <group>-table
+       └─ goka.emit
+            └─ Produce Topic <output>
+```
+
+`WrapConsumerGroupHandler` is optional if you only want callback-scoped and produce spans. Keep it when you want Datadog Data Streams consumer-group tagging or claim-level spans as well.
+
+## OpenTelemetry
+
+Use the same goka options with otelsarama's `WrapConsumerGroupHandler` and `WrapAsyncProducer`, and propagate with `otel.GetTextMapPropagator().Extract` / `Inject` against `goka.TextMapHeaders`. Start the callback span in `WithProcessMiddleware` the same way as in the Datadog example; otelsarama's consumer-group wrapper finishes its receive span at claim handoff, so middleware is still where handler duration should be measured.

--- a/header_test.go
+++ b/header_test.go
@@ -1,6 +1,7 @@
 package goka
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -34,5 +35,62 @@ func TestHeaders_Merged(t *testing.T) {
 	if string(merged["key2"]) != "val2" {
 		t.Errorf("Merged failed: expected %q for key %q, but found %q",
 			"val2", "key2", string(merged["key2"]))
+	}
+}
+
+func TestTextMapHeaders(t *testing.T) {
+	h := Headers{"traceparent": []byte("00-abc")}
+	carrier := TextMapHeaders(h)
+
+	if got := carrier.Get("traceparent"); got != "00-abc" {
+		t.Errorf("Get: got %q, want %q", got, "00-abc")
+	}
+	if got := carrier.Get("missing"); got != "" {
+		t.Errorf("Get missing: got %q, want empty", got)
+	}
+
+	carrier.Set("x-datadog-trace-id", "123")
+	if string(h["x-datadog-trace-id"]) != "123" {
+		t.Errorf("Set did not write through: %q", h["x-datadog-trace-id"])
+	}
+
+	keys := carrier.Keys()
+	if len(keys) != 2 {
+		t.Errorf("Keys: got %d, want 2", len(keys))
+	}
+
+	seen := map[string]string{}
+	err := carrier.ForeachKey(func(key, val string) error {
+		seen[key] = val
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForeachKey: %v", err)
+	}
+	if seen["traceparent"] != "00-abc" || seen["x-datadog-trace-id"] != "123" {
+		t.Errorf("ForeachKey seen: %#v", seen)
+	}
+
+	stop := errors.New("stop")
+	err = carrier.ForeachKey(func(key, val string) error {
+		return stop
+	})
+	if !errors.Is(err, stop) {
+		t.Errorf("ForeachKey should return handler error, got %v", err)
+	}
+
+	var nilCarrier TextMapHeaders
+	if nilCarrier.Get("x") != "" {
+		t.Errorf("nil Get should return empty")
+	}
+	nilCarrier.Set("x", "y") // must not panic
+	if nilCarrier.Keys() != nil {
+		t.Errorf("nil Keys should return nil")
+	}
+	if err := nilCarrier.ForeachKey(func(key, val string) error {
+		t.Errorf("unexpected key %q", key)
+		return nil
+	}); err != nil {
+		t.Errorf("nil ForeachKey: %v", err)
 	}
 }

--- a/headers.go
+++ b/headers.go
@@ -87,3 +87,54 @@ func allEmpty(headersList ...Headers) bool {
 	}
 	return true
 }
+
+// TextMapHeaders adapts Headers for text-map propagation carriers.
+// It implements OpenTelemetry's TextMapCarrier (Get/Set/Keys) and Datadog's
+// TextMapWriter/TextMapReader (Set/ForeachKey). Set mutates the underlying map;
+// callers should start from a non-nil Headers (or a copy) when injecting onto
+// outgoing messages.
+type TextMapHeaders Headers
+
+// Get returns the value associated with the given key, or the empty string if
+// the key is missing.
+func (h TextMapHeaders) Get(key string) string {
+	if h == nil {
+		return ""
+	}
+	v, ok := h[key]
+	if !ok {
+		return ""
+	}
+	return string(v)
+}
+
+// Set stores the key-value pair. If the receiver is nil, Set is a no-op.
+func (h TextMapHeaders) Set(key, value string) {
+	if h == nil {
+		return
+	}
+	h[key] = []byte(value)
+}
+
+// Keys lists the keys stored in the carrier.
+func (h TextMapHeaders) Keys() []string {
+	if len(h) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// ForeachKey calls handler for each key/value pair. It returns the first error
+// returned by handler.
+func (h TextMapHeaders) ForeachKey(handler func(key, val string) error) error {
+	for k, v := range h {
+		if err := handler(k, string(v)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/integrationtest/processor_test.go
+++ b/integrationtest/processor_test.go
@@ -293,6 +293,43 @@ func TestProcessorContextWrapper(t *testing.T) {
 	<-done
 }
 
+func TestProcessorProcessMiddleware(t *testing.T) {
+	gkt := tester.New(t)
+	var order []string
+
+	proc, err := goka.NewProcessor([]string{}, goka.DefineGroup("proc",
+		goka.Input("input", new(codec.Int64), func(ctx goka.Context, msg interface{}) {
+			order = append(order, "handler")
+			ctx.SetValue(msg)
+		}),
+		goka.Persist(new(codec.Int64)),
+	),
+		goka.WithTester(gkt),
+		goka.WithProcessMiddleware(func(next goka.ProcessCallback) goka.ProcessCallback {
+			return func(ctx goka.Context, msg interface{}) {
+				order = append(order, "mw-before")
+				next(ctx, msg)
+				order = append(order, "mw-after")
+			}
+		}),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		require.NoError(t, proc.Run(ctx))
+	}()
+
+	gkt.Consume("input", "key", int64(23))
+	require.Equal(t, []string{"mw-before", "handler", "mw-after"}, order)
+	require.EqualValues(t, 23, gkt.TableValue("proc-table", "key"))
+
+	cancel()
+	<-done
+}
+
 /*
 import (
 	"context"

--- a/options.go
+++ b/options.go
@@ -138,16 +138,18 @@ type poptions struct {
 	log      logger
 	clientID string
 
-	updateCallback         UpdateCallback
-	rebalanceCallback      RebalanceCallback
-	contextWrapper         ContextWrapper
-	partitionChannelSize   int
-	hasher                 func() hash.Hash32
-	nilHandling            NilHandling
-	backoffResetTime       time.Duration
-	hotStandby             bool
-	recoverAhead           bool
-	producerDefaultHeaders Headers
+	updateCallback               UpdateCallback
+	rebalanceCallback            RebalanceCallback
+	contextWrapper               ContextWrapper
+	processMiddlewares           []ProcessMiddleware
+	consumerGroupHandlerWrapper  ConsumerGroupHandlerWrapper
+	partitionChannelSize         int
+	hasher                       func() hash.Hash32
+	nilHandling                  NilHandling
+	backoffResetTime             time.Duration
+	hotStandby                   bool
+	recoverAhead                 bool
+	producerDefaultHeaders       Headers
 
 	builders struct {
 		storage        storage.Builder
@@ -159,12 +161,36 @@ type poptions struct {
 	}
 }
 
+// ConsumerGroupHandlerWrapper wraps the processor's ConsumerGroupHandler before
+// it is passed to ConsumerGroup.Consume.
+type ConsumerGroupHandlerWrapper func(sarama.ConsumerGroupHandler) sarama.ConsumerGroupHandler
+
+// ProcessMiddleware wraps ProcessCallback for input and visit handling.
+// Middlewares are composed so the first registered is outermost.
+type ProcessMiddleware func(next ProcessCallback) ProcessCallback
+
 // WithContextWrapper allows to intercept the context passed to each callback invocation.
 // The wrapper function will be called concurrently across all partitions the returned context
 // must not be shared.
 func WithContextWrapper(wrapper ContextWrapper) ProcessorOption {
 	return func(o *poptions, gg *GroupGraph) {
 		o.contextWrapper = wrapper
+	}
+}
+
+// WithProcessMiddleware registers middleware around ProcessCallback (inputs and visits).
+// Multiple middlewares may be registered; the first registered is outermost.
+func WithProcessMiddleware(mw ProcessMiddleware) ProcessorOption {
+	return func(o *poptions, gg *GroupGraph) {
+		o.processMiddlewares = append(o.processMiddlewares, mw)
+	}
+}
+
+// WithConsumerGroupHandlerWrapper wraps the processor handler passed to
+// ConsumerGroup.Consume.
+func WithConsumerGroupHandlerWrapper(w ConsumerGroupHandlerWrapper) ProcessorOption {
+	return func(o *poptions, gg *GroupGraph) {
+		o.consumerGroupHandlerWrapper = w
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -163,7 +163,7 @@ type poptions struct {
 
 // ConsumerGroupHandlerWrapper wraps the processor's ConsumerGroupHandler before
 // it is passed to ConsumerGroup.Consume.
-type ConsumerGroupHandlerWrapper func(sarama.ConsumerGroupHandler) sarama.ConsumerGroupHandler
+type ConsumerGroupHandlerWrapper func(handler sarama.ConsumerGroupHandler, group, clientID string) sarama.ConsumerGroupHandler
 
 // ProcessMiddleware wraps ProcessCallback for input and visit handling.
 // Middlewares are composed so the first registered is outermost.

--- a/partition_processor.go
+++ b/partition_processor.go
@@ -555,6 +555,7 @@ func (pp *PartitionProcessor) processVisit(ctx context.Context, wg *sync.WaitGro
 	}()
 
 	// now call cb, wrap the context
+	cb = pp.applyProcessMiddlewares(cb)
 	cb(pp.opts.contextWrapper(msgContext), v.meta)
 	msgContext.finish(nil)
 	return
@@ -617,9 +618,17 @@ func (pp *PartitionProcessor) processMessage(ctx context.Context, wg *sync.WaitG
 	msgContext.start()
 
 	// now call cb
+	cb = pp.applyProcessMiddlewares(cb)
 	cb(pp.opts.contextWrapper(msgContext), m)
 	msgContext.finish(nil)
 	return nil
+}
+
+func (pp *PartitionProcessor) applyProcessMiddlewares(cb ProcessCallback) ProcessCallback {
+	for i := len(pp.opts.processMiddlewares) - 1; i >= 0; i-- {
+		cb = pp.opts.processMiddlewares[i](cb)
+	}
+	return cb
 }
 
 // VisitValues iterates over all values in the table and calls the "visit"-callback for the passed name.

--- a/processor.go
+++ b/processor.go
@@ -379,7 +379,7 @@ func (g *Processor) rebalanceLoop(ctx context.Context) (rerr error) {
 			g.handleSessionErrors(ctx, sessionCtx, sessionCtxCancel, consumerGroup)
 		}()
 
-		err := consumerGroup.Consume(ctx, topics, g)
+		err := consumerGroup.Consume(ctx, topics, g.consumerGroupHandler())
 		sessionCtxCancel()
 
 		// error consuming, no way to recover so we have to kill the processor
@@ -395,6 +395,14 @@ func (g *Processor) rebalanceLoop(ctx context.Context) (rerr error) {
 			return nil
 		}
 	}
+}
+
+func (g *Processor) consumerGroupHandler() sarama.ConsumerGroupHandler {
+	var handler sarama.ConsumerGroupHandler = g
+	if g.opts.consumerGroupHandlerWrapper != nil {
+		handler = g.opts.consumerGroupHandlerWrapper(handler)
+	}
+	return handler
 }
 
 func (g *Processor) handleSessionErrors(ctx, sessionCtx context.Context, sessionCtxCancel context.CancelFunc, consumerGroup sarama.ConsumerGroup) {

--- a/processor.go
+++ b/processor.go
@@ -400,7 +400,7 @@ func (g *Processor) rebalanceLoop(ctx context.Context) (rerr error) {
 func (g *Processor) consumerGroupHandler() sarama.ConsumerGroupHandler {
 	var handler sarama.ConsumerGroupHandler = g
 	if g.opts.consumerGroupHandlerWrapper != nil {
-		handler = g.opts.consumerGroupHandlerWrapper(handler)
+		handler = g.opts.consumerGroupHandlerWrapper(handler, string(g.graph.Group()), g.opts.clientID)
 	}
 	return handler
 }

--- a/producer.go
+++ b/producer.go
@@ -25,16 +25,20 @@ type producer struct {
 func NewProducer(brokers []string, config *sarama.Config) (Producer, error) {
 	aprod, err := sarama.NewAsyncProducer(brokers, config)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to start Sarama producer: %v", err)
+		return nil, fmt.Errorf("failed to start Sarama producer: %w", err)
 	}
+	return NewProducerFromAsyncProducer(aprod), nil
+}
 
-	p := producer{
+// NewProducerFromAsyncProducer creates a goka Producer from an existing
+// sarama.AsyncProducer. The returned Producer drains Successes/Errors to
+// resolve Promises.
+func NewProducerFromAsyncProducer(aprod sarama.AsyncProducer) Producer {
+	p := &producer{
 		producer: aprod,
 	}
-
 	p.run()
-
-	return &p, nil
+	return p
 }
 
 // Close stops the producer and waits for the Success/Error channels to drain.

--- a/producer_from_async_test.go
+++ b/producer_from_async_test.go
@@ -90,13 +90,13 @@ func TestNewProducerFromAsyncProducer_UsesWrappedProducer(t *testing.T) {
 	ap := newMockAsyncProducer()
 	cfg := DefaultConfig()
 	var wrapped bool
-	wrap := AsyncProducerWrapper(func(p sarama.AsyncProducer, c *sarama.Config) sarama.AsyncProducer {
+	wrap := AsyncProducerWrapper(func(c *sarama.Config, p sarama.AsyncProducer) sarama.AsyncProducer {
 		wrapped = true
 		require.Equal(t, cfg, c)
 		return p
 	})
 
-	prod := NewProducerFromAsyncProducer(wrap(ap, cfg))
+	prod := NewProducerFromAsyncProducer(wrap(cfg, ap))
 	require.True(t, wrapped)
 	require.NotNil(t, prod)
 
@@ -105,8 +105,24 @@ func TestNewProducerFromAsyncProducer_UsesWrappedProducer(t *testing.T) {
 	require.NoError(t, prod.Close())
 }
 
-func TestProducerBuilderWithAsyncProducerWrapper_NilWrap(t *testing.T) {
+func TestWithAsyncProducerWrapper(t *testing.T) {
+	opts := &producerBuilderOptions{}
+	ap := newMockAsyncProducer()
 	cfg := DefaultConfig()
-	builder := ProducerBuilderWithAsyncProducerWrapper(cfg, nil)
+	var called bool
+	WithAsyncProducerWrapper(func(c *sarama.Config, p sarama.AsyncProducer) sarama.AsyncProducer {
+		called = true
+		require.Equal(t, cfg, c)
+		return p
+	})(opts)
+
+	require.NotNil(t, opts.asyncProducerWrapper)
+	result := opts.asyncProducerWrapper(cfg, ap)
+	require.True(t, called)
+	require.Equal(t, ap, result)
+}
+
+func TestProducerBuilderWithConfig_NoOptions(t *testing.T) {
+	builder := ProducerBuilderWithConfig(DefaultConfig())
 	require.NotNil(t, builder)
 }

--- a/producer_from_async_test.go
+++ b/producer_from_async_test.go
@@ -1,0 +1,112 @@
+package goka
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/require"
+)
+
+type mockAsyncProducer struct {
+	input     chan *sarama.ProducerMessage
+	successes chan *sarama.ProducerMessage
+	errors    chan *sarama.ProducerError
+	closeOnce sync.Once
+}
+
+func newMockAsyncProducer() *mockAsyncProducer {
+	return &mockAsyncProducer{
+		input:     make(chan *sarama.ProducerMessage, 16),
+		successes: make(chan *sarama.ProducerMessage, 16),
+		errors:    make(chan *sarama.ProducerError, 16),
+	}
+}
+
+func (m *mockAsyncProducer) AsyncClose() {
+	m.closeOnce.Do(func() {
+		close(m.input)
+	})
+}
+
+func (m *mockAsyncProducer) Close() error {
+	m.AsyncClose()
+	return nil
+}
+
+func (m *mockAsyncProducer) Input() chan<- *sarama.ProducerMessage {
+	return m.input
+}
+
+func (m *mockAsyncProducer) Successes() <-chan *sarama.ProducerMessage {
+	return m.successes
+}
+
+func (m *mockAsyncProducer) Errors() <-chan *sarama.ProducerError {
+	return m.errors
+}
+
+func (m *mockAsyncProducer) IsTransactional() bool                   { return false }
+func (m *mockAsyncProducer) TxnStatus() sarama.ProducerTxnStatusFlag { return 0 }
+func (m *mockAsyncProducer) BeginTxn() error                         { return nil }
+func (m *mockAsyncProducer) CommitTxn() error                        { return nil }
+func (m *mockAsyncProducer) AbortTxn() error                         { return nil }
+func (m *mockAsyncProducer) AddOffsetsToTxn(map[string][]*sarama.PartitionOffsetMetadata, string) error {
+	return nil
+}
+func (m *mockAsyncProducer) AddMessageToTxn(*sarama.ConsumerMessage, string, *string) error {
+	return nil
+}
+
+func TestNewProducerFromAsyncProducer_ResolvesPromise(t *testing.T) {
+	ap := newMockAsyncProducer()
+	p := NewProducerFromAsyncProducer(ap)
+
+	done := make(chan error, 1)
+	go func() {
+		msg := <-ap.input
+		ap.successes <- msg
+	}()
+
+	promise := p.Emit("topic", "key", []byte("value"))
+	promise.Then(func(err error) {
+		done <- err
+	})
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("promise was not resolved")
+	}
+
+	close(ap.successes)
+	close(ap.errors)
+	require.NoError(t, p.Close())
+}
+
+func TestNewProducerFromAsyncProducer_UsesWrappedProducer(t *testing.T) {
+	ap := newMockAsyncProducer()
+	cfg := DefaultConfig()
+	var wrapped bool
+	wrap := AsyncProducerWrapper(func(p sarama.AsyncProducer, c *sarama.Config) sarama.AsyncProducer {
+		wrapped = true
+		require.Equal(t, cfg, c)
+		return p
+	})
+
+	prod := NewProducerFromAsyncProducer(wrap(ap, cfg))
+	require.True(t, wrapped)
+	require.NotNil(t, prod)
+
+	close(ap.successes)
+	close(ap.errors)
+	require.NoError(t, prod.Close())
+}
+
+func TestProducerBuilderWithAsyncProducerWrapper_NilWrap(t *testing.T) {
+	cfg := DefaultConfig()
+	builder := ProducerBuilderWithAsyncProducerWrapper(cfg, nil)
+	require.NotNil(t, builder)
+}

--- a/tracing_hooks_test.go
+++ b/tracing_hooks_test.go
@@ -44,23 +44,25 @@ func TestWithProcessMiddleware_CompositionOrder(t *testing.T) {
 }
 
 func TestWithConsumerGroupHandlerWrapper(t *testing.T) {
-	opts := &poptions{}
-	gg := new(GroupGraph)
-	var called bool
+	opts := &poptions{clientID: "test-client"}
+	gg := DefineGroup("test-group")
+	var gotGroup, gotClientID string
 
-	WithConsumerGroupHandlerWrapper(func(h sarama.ConsumerGroupHandler) sarama.ConsumerGroupHandler {
-		called = true
+	WithConsumerGroupHandlerWrapper(func(h sarama.ConsumerGroupHandler, group, clientID string) sarama.ConsumerGroupHandler {
+		gotGroup = group
+		gotClientID = clientID
 		require.NotNil(t, h)
 		return h
 	})(opts, gg)
 
-	g := &Processor{opts: opts}
+	g := &Processor{opts: opts, graph: gg}
 	handler := g.consumerGroupHandler()
-	require.True(t, called)
+	require.Equal(t, "test-group", gotGroup)
+	require.Equal(t, "test-client", gotClientID)
 	require.Equal(t, g, handler)
 }
 
 func TestWithConsumerGroupHandlerWrapper_Nil(t *testing.T) {
-	g := &Processor{opts: &poptions{}}
+	g := &Processor{opts: &poptions{}, graph: DefineGroup("test-group")}
 	require.Equal(t, g, g.consumerGroupHandler())
 }

--- a/tracing_hooks_test.go
+++ b/tracing_hooks_test.go
@@ -1,0 +1,66 @@
+package goka
+
+import (
+	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithProcessMiddleware_CompositionOrder(t *testing.T) {
+	var order []string
+	opts := &poptions{}
+	gg := new(GroupGraph)
+
+	WithProcessMiddleware(func(next ProcessCallback) ProcessCallback {
+		return func(ctx Context, msg interface{}) {
+			order = append(order, "outer-before")
+			next(ctx, msg)
+			order = append(order, "outer-after")
+		}
+	})(opts, gg)
+
+	WithProcessMiddleware(func(next ProcessCallback) ProcessCallback {
+		return func(ctx Context, msg interface{}) {
+			order = append(order, "inner-before")
+			next(ctx, msg)
+			order = append(order, "inner-after")
+		}
+	})(opts, gg)
+
+	pp := &PartitionProcessor{opts: opts}
+	cb := pp.applyProcessMiddlewares(func(ctx Context, msg interface{}) {
+		order = append(order, "handler")
+	})
+	cb(nil, nil)
+
+	require.Equal(t, []string{
+		"outer-before",
+		"inner-before",
+		"handler",
+		"inner-after",
+		"outer-after",
+	}, order)
+}
+
+func TestWithConsumerGroupHandlerWrapper(t *testing.T) {
+	opts := &poptions{}
+	gg := new(GroupGraph)
+	var called bool
+
+	WithConsumerGroupHandlerWrapper(func(h sarama.ConsumerGroupHandler) sarama.ConsumerGroupHandler {
+		called = true
+		require.NotNil(t, h)
+		return h
+	})(opts, gg)
+
+	g := &Processor{opts: opts}
+	handler := g.consumerGroupHandler()
+	require.True(t, called)
+	require.Equal(t, g, handler)
+}
+
+func TestWithConsumerGroupHandlerWrapper_Nil(t *testing.T) {
+	g := &Processor{opts: &poptions{}}
+	require.Equal(t, g, g.consumerGroupHandler())
+}


### PR DESCRIPTION
Goka does not expose seams needed by Datadog's IBM/sarama contrib or
otelsarama (WrapConsumerGroupHandler, WrapAsyncProducer). Without them,
apps cannot easily instrument consume→process→emit without forking internals.

Add dependency-free hooks so integrators can plug those wrappers in:
- WithConsumerGroupHandlerWrapper for consumer-group instrumentation
  (receives group and clientID, matching ConsumerGroupBuilder)
- NewProducerFromAsyncProducer / ProducerBuilderWithConfig with WithAsyncProducerWrapper
  for AsyncProducer wrapping before the Promise loop
- WithProcessMiddleware so process spans can cover ProcessCallback
  (claim-level library spans end too early for goka's async queue)
- TextMapHeaders for trace extract/inject against message headers

See docs/tracing.md for integration examples.