### PR TITLE
 Add public API for computing partition assignment from a key

### DIFF
--- a/partition.go
+++ b/partition.go
@@ -1,0 +1,31 @@
+package goka
+
+import (
+	"fmt"
+	"hash"
+)
+
+// PartitionForKey calculates the partition ID for a given key using the provided
+// hasher factory and partition count. This uses the same algorithm as View.hash()
+// and Processor.hash() internally, making it safe to predict partition assignments
+// externally without access to a running View or Processor instance.
+//
+// Use DefaultHasher() as the hasher argument unless a custom hasher was configured
+// via WithHasher/WithViewHasher/WithEmitterHasher when creating the View/Processor.
+func PartitionForKey(key []byte, numPartitions int32, hasher func() hash.Hash32) (int32, error) {
+	if numPartitions <= 0 {
+		return 0, fmt.Errorf("invalid partition count: %d", numPartitions)
+	}
+
+	h := hasher()
+	_, err := h.Write(key)
+	if err != nil {
+		return -1, fmt.Errorf("failed to hash key: %w", err)
+	}
+
+	p := int32(h.Sum32())
+	if p < 0 {
+		p = -p
+	}
+	return p % numPartitions, nil
+}

--- a/partition_test.go
+++ b/partition_test.go
@@ -1,0 +1,149 @@
+package goka
+
+import (
+	"hash"
+	"hash/fnv"
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+func TestPartitionForKey(t *testing.T) {
+	t.Run("basic partition calculation", func(t *testing.T) {
+		hasher := DefaultHasher()
+		keys := []string{"cs12345", "fs67890", "cs99999", "test-key"}
+
+		for _, key := range keys {
+			partition, err := PartitionForKey([]byte(key), 64, hasher)
+			if err != nil {
+				t.Fatalf("unexpected error for key %q: %v", key, err)
+			}
+			if partition < 0 || partition >= 64 {
+				t.Errorf("partition %d out of range [0, 64) for key %q", partition, key)
+			}
+		}
+	})
+
+	t.Run("deterministic results", func(t *testing.T) {
+		hasher := DefaultHasher()
+		key := []byte("cs12345")
+
+		p1, _ := PartitionForKey(key, 64, hasher)
+		p2, _ := PartitionForKey(key, 64, hasher)
+
+		if p1 != p2 {
+			t.Errorf("non-deterministic: got %d and %d for same key", p1, p2)
+		}
+	})
+
+	t.Run("single partition", func(t *testing.T) {
+		hasher := DefaultHasher()
+		partition, err := PartitionForKey([]byte("any-key"), 1, hasher)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if partition != 0 {
+			t.Errorf("expected partition 0 for single partition, got %d", partition)
+		}
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		hasher := DefaultHasher()
+		partition, err := PartitionForKey([]byte(""), 64, hasher)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if partition < 0 || partition >= 64 {
+			t.Errorf("partition %d out of range for empty key", partition)
+		}
+	})
+
+	t.Run("invalid partition count", func(t *testing.T) {
+		hasher := DefaultHasher()
+
+		_, err := PartitionForKey([]byte("key"), 0, hasher)
+		if err == nil {
+			t.Error("expected error for 0 partitions")
+		}
+
+		_, err = PartitionForKey([]byte("key"), -1, hasher)
+		if err == nil {
+			t.Error("expected error for negative partitions")
+		}
+	})
+
+	t.Run("matches sarama HashPartitioner", func(t *testing.T) {
+		hasher := DefaultHasher()
+		partitionerConstructor := sarama.NewCustomHashPartitioner(hasher)
+		partitioner := partitionerConstructor("") // instantiate with empty topic
+
+		keys := []string{"cs12345", "fs67890", "cs99999", "fs00001", "ci55555"}
+		partitionCounts := []int32{16, 32, 64, 128}
+
+		for _, numPartitions := range partitionCounts {
+			for _, key := range keys {
+				gokaPartition, err := PartitionForKey([]byte(key), numPartitions, hasher)
+				if err != nil {
+					t.Fatalf("PartitionForKey error: %v", err)
+				}
+
+				msg := &sarama.ProducerMessage{Key: sarama.StringEncoder(key)}
+				saramaPartition, err := partitioner.Partition(msg, numPartitions)
+				if err != nil {
+					t.Fatalf("sarama Partition error: %v", err)
+				}
+
+				if gokaPartition != saramaPartition {
+					t.Errorf("key=%q partitions=%d: goka=%d sarama=%d",
+						key, numPartitions, gokaPartition, saramaPartition)
+				}
+			}
+		}
+	})
+
+	t.Run("matches internal View.hash logic", func(t *testing.T) {
+		// Verify that PartitionForKey produces the same result as the internal
+		// hash algorithm used by View.hash() / Processor.hash()
+		hasher := DefaultHasher()
+		keys := []string{"cs12345", "fs67890", "test-key-123"}
+		numPartitions := int32(64)
+
+		for _, key := range keys {
+			// Replicate View.hash() logic directly
+			h := fnv.New32a()
+			h.Write([]byte(key))
+			expected := int32(h.Sum32())
+			if expected < 0 {
+				expected = -expected
+			}
+			expected = expected % numPartitions
+
+			got, err := PartitionForKey([]byte(key), numPartitions, hasher)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != expected {
+				t.Errorf("key=%q: PartitionForKey=%d, manual hash=%d", key, got, expected)
+			}
+		}
+	})
+
+	t.Run("custom hasher", func(t *testing.T) {
+		// Verify that a custom hasher produces different results than default
+		customHasher := func() hash.Hash32 {
+			return fnv.New32() // FNV-1 (not FNV-1a)
+		}
+
+		key := []byte("test-key")
+		defaultPartition, _ := PartitionForKey(key, 64, DefaultHasher())
+		customPartition, _ := PartitionForKey(key, 64, customHasher)
+
+		// They may or may not differ for a specific key, but the function should work
+		// Just verify no error and valid range
+		if customPartition < 0 || customPartition >= 64 {
+			t.Errorf("custom hasher partition %d out of range", customPartition)
+		}
+		_ = defaultPartition
+	})
+}

--- a/processor.go
+++ b/processor.go
@@ -220,23 +220,7 @@ func (g *Processor) setPartProc(partition int32, pproc *PartitionProcessor) {
 }
 
 func (g *Processor) hash(key string) (int32, error) {
-	// create a new hasher every time. Alternative would be to store the hash in
-	// view and every time reset the hasher (ie, hasher.Reset()). But that would
-	// also require us to protect the access of the hasher with a mutex.
-	hasher := g.opts.hasher()
-
-	_, err := hasher.Write([]byte(key))
-	if err != nil {
-		return -1, err
-	}
-	hash := int32(hasher.Sum32())
-	if hash < 0 {
-		hash = -hash
-	}
-	if g.partitionCount == 0 {
-		return 0, errors.New("can't hash with 0 partitions")
-	}
-	return hash % int32(g.partitionCount), nil
+	return PartitionForKey([]byte(key), int32(g.partitionCount), g.opts.hasher)
 }
 
 // Run starts the processor using passed context.

--- a/view.go
+++ b/view.go
@@ -2,7 +2,6 @@ package goka
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -295,23 +294,7 @@ func (v *View) close() error {
 }
 
 func (v *View) hash(key string) (int32, error) {
-	// create a new hasher every time. Alternative would be to store the hash in
-	// view and every time reset the hasher (ie, hasher.Reset()). But that would
-	// also require us to protect the access of the hasher with a mutex.
-	hasher := v.opts.hasher()
-
-	_, err := hasher.Write([]byte(key))
-	if err != nil {
-		return -1, err
-	}
-	hash := int32(hasher.Sum32())
-	if hash < 0 {
-		hash = -hash
-	}
-	if len(v.partitions) == 0 {
-		return 0, errors.New("no partitions found")
-	}
-	return hash % int32(len(v.partitions)), nil
+	return PartitionForKey([]byte(key), int32(len(v.partitions)), v.opts.hasher)
 }
 
 func (v *View) find(key string) (*PartitionTable, error) {


### PR DESCRIPTION
 **Summary**

Goka's own partition assignment logic (View.hash()/Processor.hash()) is unexported in goka. In case if the client required to detect partition id by the key, he has to create his own version of the consistent hashing. There is a high possibility, that the logic could be changed and hashing calculation would silently diverge. 

  Adds _PartitionForKey(key []byte, numPartitions int32, hasher func() hash.Hash32) (int32, error)_, a new exported function that computes the partition a key would be assigned to, using the same hash-and-mod algorithm goka already uses internally in Processor.hash and View.hash.

  This lets external callers predict partition assignment (e.g. for routing, sharding-aware batching, or debugging) without needing a running View or Processor instance.

  Changes

  - partition.go (new): PartitionForKey — validates numPartitions > 0, hashes the key with the provided hasher factory, and returns hash % numPartitions.
  - partition_test.go (new): covers basic range/determinism checks, single-partition behavior, empty keys, invalid partition counts, parity with
  sarama.NewCustomHashPartitioner, parity with the previous internal View.hash logic, and custom hasher usage.
  - processor.go: Processor.hash now delegates to PartitionForKey instead of inlining the hash logic.
  - view.go: View.hash now delegates to PartitionForKey instead of inlining the hash logic; drops the now-unused errors import.

  Behavior notes

  - Same algorithm as before (FNV hash via DefaultHasher(), or whatever hasher was configured via WithHasher/WithViewHasher/WithEmitterHasher) — this is a refactor of
  the internal call sites, not a behavior change for existing users.
  - Error messages changed slightly ("can't hash with 0 partitions" / "no partitions found" → "invalid partition count: %d"); nothing in the codebase asserts on the
  old strings.
  - Callers must supply the same numPartitions and hasher that the live Processor/View uses — PartitionForKey doesn't read from a running instance, so a mismatch
  (e.g. wrong partition count, or DefaultHasher() when a custom hasher was configured) will silently produce a different partition than the real one.

  Testing

  - partition_test.go verifies PartitionForKey matches both the sarama hash partitioner and the previous internal hashing logic across multiple keys and partition
  counts.
  - Existing processor.go/view.go test suites (view_test.go, etc.) continue to exercise the refactored hash methods unchanged.